### PR TITLE
feat(metaconfig): for new config sources, add groupable options and refactor mutual exclusion

### DIFF
--- a/simpl/config.py
+++ b/simpl/config.py
@@ -219,7 +219,7 @@ class Option(object):
         updater = {k: v for k, v in copy.copy(self.__dict__).items()
                    if k not in ('args', 'kwargs')}
         newone.__dict__.update(updater)
-        assert not newone.kwargs is self.kwargs
+        assert newone.kwargs is not self.kwargs
         return newone
 
     def __repr__(self):
@@ -335,7 +335,8 @@ class Config(collections.MutableMapping):
 
     """Parses configuration sources."""
 
-    def __init__(self, options=None, ini_paths=None, argv=None, **parser_kwargs):
+    def __init__(self, options=None, ini_paths=None, argv=None,
+                 **parser_kwargs):
         """Initialize with list of options.
 
         :param ini_paths: optional paths to ini files to look up values from
@@ -593,7 +594,8 @@ class Config(collections.MutableMapping):
                 if option.dest not in results or results[option.dest] is None:
                     if getattr(option, '_mutexgroup', None):
                         raise_for_group.setdefault(option._mutexgroup, [])
-                        raise_for_group[option._mutexgroup].append(option._action)
+                        raise_for_group[option._mutexgroup].append(
+                            option._action)
                     else:
                         raise SystemExit("'%s' is required. See --help "
                                          "for more info." % option.name)
@@ -693,7 +695,8 @@ class MetaConfig(Config):
     """
 
     option_group = 'initialization (metaconfig) arguments'
-    option_description = 'evaluated first and can be used to source an entire config'
+    option_description = ('evaluated first and can be used to '
+                          'source an entire config')
 
     options = [
         Option('--ini', metavar='PATH',
@@ -773,7 +776,7 @@ if __name__ == '__main__':
         Option('--key-thing', group='secret'),
         Option('--this', group='things'),
         Option('--who', group='group of its own'),
-        #Option('--more', mutually_exclusive=True),  # should fail
+        #  Option('--more', mutually_exclusive=True),  # should fail
         Option('--more', mutually_exclusive=True, dest='more'),  # should be ok
         Option('--less', mutually_exclusive=True, dest='more'),  # should be ok
     ]

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -718,3 +718,25 @@ def comma_separated_pairs(value):
 def parse_key_format(value):
     """Handle string formats of key files."""
     return value.strip("'").replace('\\n', '\n')
+
+
+if __name__ == '__main__':
+
+    opts = [
+        Option('--foo'),
+        Option('--bar'),
+        Option('--baz'),
+        Option('--key', group='secret', mutually_exclusive=True),
+        Option('--key-file', group='secret', mutually_exclusive=True),
+        Option('--key-thing', group='secret'),
+        Option('--this', group='things'),
+        Option('--who', group='group of its own'),
+        #Option('--more', mutually_exclusive=True),  # should fail
+        Option('--more', mutually_exclusive=True, dest='more'),  # should be ok
+        Option('--less', mutually_exclusive=True, dest='more'),  # should be ok
+    ]
+    myconf = Config(options=opts)
+    if len(sys.argv) == 1:
+        sys.argv.append('--help')
+    myconf.parse()
+    print(myconf)

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -213,16 +213,12 @@ class Option(object):
                 del kwargs['ini_section']
             except KeyError:
                 pass
-            if 'mutually_exclusive_group' in kwargs:
+            if kwargs.get('mutually_exclusive_group'):
                 required = kwargs.pop('required', None)
                 groupname = kwargs.pop('mutually_exclusive_group')
                 megroup = [grp for grp in parser._mutually_exclusive_groups
                            if grp.title == groupname]
                 if megroup:
-                    if len(megroup) != 1:
-                        raise ValueError(
-                            "Bug: Mutiple mutually exclusive "
-                            "groups with the same title were found.")
                     megroup = megroup[0]
                     action = megroup.add_argument(*self.args, **kwargs)
                 else:
@@ -232,6 +228,19 @@ class Option(object):
                     action = megroup.add_argument(*self.args, **kwargs)
                 self._megroup = megroup
                 self._action = action
+            elif kwargs.get('group'):
+                groupname = kwargs.pop('group')
+                description = kwargs.pop('group_description', None)
+                exists = [grp for grp in parser._action_groups
+                          if k.title == groupname]
+                if exists:
+                    group = exists[0]
+                    if description and not group.description:
+                        group.description = description
+                else:
+                    parser.add_argument_group(title=groupname,
+                                              description=description)
+                    grp.add_argument(*self.args, **kwargs)
 
                 return
         kwargs.update(override_kwargs)

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -174,7 +174,7 @@ class SimplConfigError(Exception):
     """Base class for exceptions."""
 
 
-class NoGroupforOption(SimplConfigError):
+class NoGroupForOption(SimplConfigError):
 
     """Mutually exclusive option requires a group name."""
 
@@ -263,8 +263,8 @@ class Option(object):
                 groupname = kwargs.pop('group', None) or kwargs.get('dest')
                 mutually_exclusive = kwargs.pop('mutually_exclusive', None)
                 if not groupname:
-                    raise NoGroupforOption(
-                        "Option %s requires either 'group' or 'dest'." % self)
+                    raise NoGroupForOption(
+                        "%s requires either 'group' or 'dest'." % self)
                 description = kwargs.pop('group_description', None)
                 exists = [grp for grp in parser._action_groups
                           if grp.title == groupname]

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -502,7 +502,14 @@ class Config(collections.MutableMapping):
 
     def get_defaults(self):
         """Use argparse to determine and return dict of defaults."""
-        parser = self.build_parser(self._options, permissive=True)
+        # dont need 'required' to determine the default
+        options = [copy.copy(opt) for opt in self._options]
+        for opt in options:
+            try:
+                del opt.kwargs['required']
+            except KeyError:
+                pass
+        parser = self.build_parser(options, permissive=True)
         parsed, _ = parser.parse_known_args([])
         return vars(parsed)
 

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -212,6 +212,25 @@ class Option(object):
         self._action = None
         self._mutexgroup = None
 
+    def __copy__(self):
+        cpargs = copy.copy(self.args)
+        cpkwargs = copy.copy(self.kwargs)
+        newone = type(self)(*cpargs, **cpkwargs)
+        updater = {k: v for k, v in copy.copy(self.__dict__).items()
+                   if k not in ('args', 'kwargs')}
+        newone.__dict__.update(updater)
+        assert not newone.kwargs is self.kwargs
+        return newone
+
+    def __repr__(self):
+        args = ', '.join(self.args)
+        kwrgs = ', '.join(['%s=%s' % (k, v) for k, v in self.kwargs.items()])
+        rpr = 'Option(%s' % args
+        if kwrgs:
+            rpr = '%s, %s' % (rpr, kwrgs)
+        rpr = '%s)' % rpr
+        return rpr
+
     def add_argument(self, parser, permissive=False, **override_kwargs):
         """Add an option to a an argparse parser.
 

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -350,6 +350,7 @@ class Config(collections.MutableMapping):
         self._argv = argv
         self._metaconfigure(argv=self._argv)
         self._parser = argparse.ArgumentParser(**parser_kwargs)
+        self._prog = None
         self.ini_config = None
         self.pass_thru_args = []
 
@@ -363,7 +364,13 @@ class Config(collections.MutableMapping):
     @property
     def prog(self):
         """Program name."""
-        return self._parser.prog
+        if not self._prog:
+            self._prog = self._parser.prog
+        return self._prog
+
+    @prog.setter
+    def prog(self, value):
+        self._prog = value
 
     @property
     def default_ini(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,12 @@
 # limitations under the License.
 
 """Tests for config.py"""
+from __future__ import print_function
 
 import os
+import sys
+import tempfile
+import textwrap
 import unittest
 
 import mock
@@ -80,6 +84,275 @@ class TestConfig(unittest.TestCase):
         ])
         with self.assertRaises(SystemExit):
             cfg.parse([])
+
+    def test_argparser_groups(self):
+
+        opts = [
+            config.Option('--baz'),
+            config.Option('--password', group='secret'),
+            config.Option('--key', group='secret'),
+            config.Option('--this', group='things'),
+            config.Option('--that', group='things'),
+            config.Option('--other', group='things'),
+            config.Option('--who', group='group of its own'),
+        ]
+        myconf = config.Config(options=opts)
+        parser = myconf.build_parser(opts)
+        secret_group = None
+        things_group = None
+        own_group = None
+        for grp in parser._action_groups:
+            if grp.title == 'secret':
+                secret_group = grp
+            elif grp.title == 'things':
+                things_group = grp
+            elif grp.title == 'group of its own':
+                own_group = grp
+        self.assertTrue(secret_group)
+        self.assertTrue(things_group)
+        self.assertTrue(own_group)
+
+        self.assertEqual(len(secret_group._group_actions), 2)
+        option_strings = [i for k in secret_group._group_actions
+                          for i in k.option_strings]
+        self.assertIn('--password', option_strings)
+        self.assertIn('--key', option_strings)
+        self.assertEqual(len(things_group._group_actions), 3)
+        option_strings = [i for k in things_group._group_actions
+                          for i in k.option_strings]
+        self.assertIn('--this', option_strings)
+        self.assertIn('--that', option_strings)
+        self.assertIn('--other', option_strings)
+        self.assertEqual(len(own_group._group_actions), 1)
+        option_strings = [i for k in own_group._group_actions
+                          for i in k.option_strings]
+        self.assertIn('--who', option_strings)
+
+    def test_group_help_usage_output(self):
+
+        opts = [
+            config.Option('--baz'),
+            config.Option('--password', group='secret'),
+            config.Option('--key', group='secret', group_description='haha security'),
+            config.Option('--this', group='things'),
+            config.Option('--that', group='things', group_description='define me once'),
+            config.Option('--other', group='things'),
+            config.Option('--who', group='group of its own'),
+        ]
+        myconf = config.Config(options=opts)
+        parser = myconf.build_parser(opts)
+        helplines = [k.strip() for k in parser.format_help().splitlines()]
+        self.assertIn('secret:', helplines)
+        self.assertIn('haha security', helplines)
+        self.assertIn('things:', helplines)
+        self.assertIn('define me once', helplines)
+        self.assertIn('group of its own:', helplines)
+
+    @mock.patch.object(sys, 'stderr')
+    def test_mutual_exclusion(self, mock_stderr):
+        opts = [
+            config.Option('--foo'),
+            config.Option('--key', group='secret', mutually_exclusive=True),
+            config.Option('--key-file', group='secret', dest='key',
+                          mutually_exclusive=True, type=config.read_from),
+            config.Option('--key-thing', group='secret'),
+        ]
+
+        # for read_from
+        keystring = 'this-is-a-private-key'
+        strfile = tempfile.NamedTemporaryFile()
+        strfile.write('%s-written-to-file' % keystring)
+        strfile.flush()
+
+        myconf = config.Config(options=opts)
+        argv = ['program', '--key-file', strfile.name,
+                '--key', keystring]
+
+        with self.assertRaises(SystemExit):
+            try:
+                myconf.parse(argv=argv)  # fails b/c mutual exclusion collision
+            except SystemExit as err:
+                errmsg = ('error: argument --key: '
+                          'not allowed with argument --key-file')
+                args, _ = mock_stderr.write.call_args
+                self.assertIn(errmsg, args[0])
+                raise
+
+    @mock.patch.object(sys, 'stderr')
+    def test_mutex_with_special_type(self, mock_stderr):
+        opts = [
+            config.Option('--foo'),
+            config.Option('--key', group='secret', mutually_exclusive=True),
+            config.Option('--key-file', group='secret', dest='key',
+                          mutually_exclusive=True, type=config.read_from),
+            config.Option('--key-thing', group='secret'),
+            config.Option('--more', mutually_exclusive=True, dest='more',
+                          action='store_true'),  # should be ok
+            config.Option('--less', mutually_exclusive=True, dest='more',
+                          action='store_false'),
+        ]
+
+        # for read_from
+        keystring = 'this-is-a-private-key'
+        strfile = tempfile.NamedTemporaryFile()
+        strfile.write('%s-written-to-file' % keystring)
+        strfile.flush()
+
+        myconf = config.Config(options=opts)
+        argv = ['program', '--key', keystring]
+        myconf.parse(argv=argv)
+        self.assertEqual(myconf.key, keystring)
+        argv = ['program', '--key-file', strfile.name]
+        myconf.parse(argv=argv)
+        self.assertEqual(myconf.key, '%s-written-to-file' % keystring)
+
+    def test_mutex_no_group_for_option_fail(self):
+        opts = [
+            config.Option('--ihavenogroup', mutually_exclusive=True,
+                          action='store_true'),
+        ]
+        # mutual exclusion requires a group which is derived from
+        # 'group' or 'dest'
+        myconf = config.Config(options=opts)
+        with self.assertRaises(config.NoGroupForOption):
+            myconf.build_parser(opts)
+
+    @mock.patch.object(sys, 'stderr')
+    def test_mutually_exclusive_fails_lacking(self, mock_stderr):
+        opts = [
+            config.Option('--foo'),
+            # if *any* arg in the same mutually_exclusive group says
+            # required=True, then at least one value in that mutex group
+            # will be required
+            config.Option('--more', mutually_exclusive=True, dest='more',
+                          action='store_true'),
+            config.Option('--less', mutually_exclusive=True, dest='more',
+                          action='store_false', required=True),
+        ]
+        myconf = config.Config(options=opts)
+        argv = ['program', '--foo', 'myfoo']
+        with self.assertRaises(SystemExit):
+            try:
+                myconf.parse(argv=argv)  # fails b/c mutual exclusion collision
+            except SystemExit as err:
+                errmsg = ('error: one of the '
+                          'arguments --more --less is required')
+                args, _ = mock_stderr.write.call_args
+                self.assertIn(errmsg, args[0])
+                raise
+
+    @mock.patch.object(sys, 'stderr')
+    def test_mutually_exclusive_fails_excess(self, mock_stderr):
+
+        opts = [
+            config.Option('--foo'),
+            # if *any* arg in the same mutually_exclusive group says
+            # required=True, then at least one value in that mutex group
+            # will be required
+            config.Option('--more', mutually_exclusive=True, dest='more',
+                          action='store_true'),
+            config.Option('--less', mutually_exclusive=True, dest='more',
+                          action='store_false', required=True),
+        ]
+        myconf = config.Config(options=opts)
+        argv = ['program', '--more', '--less']
+        with self.assertRaises(SystemExit):
+            try:
+                myconf.parse(argv=argv)  # fails b/c mutual exclusion collision
+            except SystemExit as err:
+                errmsg = ('error: argument --less: '
+                          'not allowed with argument --more')
+                args, _ = mock_stderr.write.call_args
+                self.assertIn(errmsg, args[0])
+                raise
+
+    def test_mutually_exclusive_dest(self):
+        """Mutually exclusive group name derived from 'dest'."""
+        opts = [
+            # if *any* arg in the same mutually_exclusive group says
+            # required=True, then at least one value in that mutex group
+            # will be required
+            config.Option('--more', mutually_exclusive=True, dest='more',
+                          action='store_true'),
+            config.Option('--less', mutually_exclusive=True, dest='more',
+                          action='store_false'),
+        ]
+        myconf = config.Config(options=opts)
+        argv = ['program']
+        # testing that this raises no error
+        myconf.parse(argv=argv)
+        argv = ['program', '--more']
+        myconf.parse(argv=argv)
+        self.assertEqual(myconf.more, True)
+        argv = ['program', '--less']
+        myconf.parse(argv=argv)
+        self.assertEqual(myconf.more, False)
+
+    def test_default_metaconfig_options(self):
+
+        myconf = config.Config()
+        metaconf = myconf._get_metaconfig_class()
+        self.assertEqual(metaconf, config.MetaConfig)
+        self.assertEqual(len(metaconf.options), 1)
+        self.assertEqual(metaconf.options[0].args, ('--ini',))
+
+    def test_metaconfig_ini(self):
+
+        metaconf = textwrap.dedent(
+            """
+            [default]
+            ham = glam
+            grand = slam
+
+            [program]
+            spam = rico
+            grand = notpreferred
+            """
+        )
+        opts = [
+            config.Option('--ham', ini_section='default'),
+            config.Option('--grand', ini_section='default'),
+            config.Option('--spam'),
+        ]
+        strfile = tempfile.NamedTemporaryFile()
+        strfile.write(metaconf)
+        strfile.flush()
+        argv = ['program', '--ini', strfile.name]
+        myconf = config.Config(options=opts, argv=argv, prog='program')
+        myconf.parse()
+        self.assertEqual(myconf.grand, 'slam')
+        self.assertEqual(myconf.ham, 'glam')
+        self.assertEqual(myconf.spam, 'rico')
+
+    def test_default_metaconfig_ini(self):
+        """A default ini file is looked for by the metaconfig.
+
+        Looks for '{cwd}/{prog}.ini' % (os.getcwd(), myconf.prog)
+        """
+        strfile = tempfile.NamedTemporaryFile(dir=os.getcwd(), suffix='.ini')
+        prog = os.path.split(strfile.name)[-1].rsplit('.ini', 1)[0]
+        metaconf = textwrap.dedent(
+            """
+            [%s]
+            ham = glam
+            grand = slam
+            spam = rico
+            """
+        ) % prog
+        opts = [
+            config.Option('--ham'),
+            config.Option('--grand'),
+            config.Option('--spam'),
+        ]
+        strfile.write(metaconf)
+        strfile.flush()
+        argv = ['program', '--ini', strfile.name]
+        myconf = config.Config(options=opts, argv=argv)
+        myconf.prog = prog
+        myconf.parse()
+        self.assertEqual(myconf.grand, 'slam')
+        self.assertEqual(myconf.ham, 'glam')
+        self.assertEqual(myconf.spam, 'rico')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
meta config options allow an entire configuration to be
specified by a single source. the only existing native
capability was the use of ini files, but there was no
way to specify which ini file, much less specify it the
same way any other Option could be specified (cli, env, keyring).

this connects a metaconfig instance that can be used to provision
an entire (or part of) a Config. the first meta option to be
implemented was `--ini` since Config natively supports parsing ini
files.

See the MetaConfig docstring for more details.

#### todo

- [x] tests