### PR TITLE
Package info simplification and reorganization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,68 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""simpl packaging and installation."""
+"""simpl packaging, installation, and package attributes."""
 
-import ast
-import re
+import os
 from setuptools import find_packages
 from setuptools import setup
 
 
-DEPENDENCIES = [
+src_dir = os.path.dirname(os.path.realpath(__file__))
+
+about = {}
+with open(os.path.join(src_dir, 'simpl', '__about__.py')) as abt:
+    exec(abt.read(), about)
+
+
+INSTALL_REQUIRES = [
     'six',
 ]
+
 TESTS_REQUIRE = [
     'mock',
 ]
 
+CLASSIFIERS = [
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Operating System :: OS Independent',
+    'Topic :: Software Development',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.4',
+]
 
-def package_meta():
-    """Read __init__.py for global package metadata.
-
-    Do this without importing the package.
-    """
-    _version_re = re.compile(r'__version__\s+=\s+(.*)')
-    _url_re = re.compile(r'__url__\s+=\s+(.*)')
-    _license_re = re.compile(r'__license__\s+=\s+(.*)')
-
-    with open('simpl/__init__.py', 'rb') as simplinit:
-        initcontent = simplinit.read()
-        version = str(ast.literal_eval(_version_re.search(
-            initcontent.decode('utf-8')).group(1)))
-        url = str(ast.literal_eval(_url_re.search(
-            initcontent.decode('utf-8')).group(1)))
-        licencia = str(ast.literal_eval(_license_re.search(
-            initcontent.decode('utf-8')).group(1)))
-    return {
-        'version': version,
-        'license': licencia,
-        'url': url,
-    }
-
-_simpl_meta = package_meta()
+package_attributes = {
+    'name': about['__title__'],
+    'description': about['__summary__'],
+    'keywords': ' '.join(about['__keywords__']),
+    'version': about['__version__'],
+    'tests_require': TESTS_REQUIRE,
+    'test_suite': 'tests',
+    'install_requires': INSTALL_REQUIRES,
+    'packages': find_packages(exclude=['tests']),
+    'author': about['__author__'],
+    'maintainer_email': about['__email__'],
+    'classifiers': CLASSIFIERS,
+    'license': about['__license__'],
+    'url': about['__url__'],
+}
 
 
-setup(
-    name='simpl',
-    description='Python common libraries',
-    keywords='common reusable amazing',
-    version=_simpl_meta['version'],
-    tests_require=TESTS_REQUIRE,
-    test_suite='tests',
-    install_requires=DEPENDENCIES,
-    packages=find_packages(exclude=['tests']),
-    maintainer='Sam Stavinoha',
-    maintainer_email='samuel.stavinoha@rackspace.com',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Topic :: Software Development',
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-    ],
-    license=_simpl_meta['license'],
-    url=_simpl_meta['url'],
-)
+setup(**package_attributes)

--- a/simpl/__about__.py
+++ b/simpl/__about__.py
@@ -28,7 +28,7 @@ __title__ = 'simpl'
 __summary__ = ('simpl is a collection of useful, '
                'reusable, common python libraries')
 __url__ = 'https://github.com/checkmate/simpl'
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 __author__ = 'Rackers'
 __email__ = 'samuel.stavinoha@rackspace.com'
 __keywords__ = ['common', 'resuable', 'suitable', 'fruitful']

--- a/simpl/__about__.py
+++ b/simpl/__about__.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Package attributes and metadata."""
+
+__all__ = (
+    '__title__',
+    '__summary__',
+    '__url__',
+    '__version__',
+    '__author__',
+    '__email__',
+    '__license__',
+    '__copyright__',
+    '__keywords__',
+)
+
+
+__title__ = 'simpl'
+__summary__ = ('simpl is a collection of useful, '
+               'reusable, common python libraries')
+__url__ = 'https://github.com/checkmate/simpl'
+__version__ = '0.2.1'
+__author__ = 'Rackers'
+__email__ = 'samuel.stavinoha@rackspace.com'
+__keywords__ = ['common', 'resuable', 'suitable', 'fruitful']
+__license__ = 'Apache License, Version 2.0'
+__copyright__ = 'Copyright Rackspace US, Inc. (c) 2014-2015'

--- a/simpl/__init__.py
+++ b/simpl/__init__.py
@@ -11,18 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""simpl common utlities library."""
-__title__ = 'simpl'
-__version__ = '0.2.1'
-__license__ = 'Apache 2.0'
-__copyright__ = 'Copyright Rackspace US, Inc. (c) 2015'
-__url__ = 'https://github.com/checkmate/simpl'
+
+"""Simpl."""
 
 import os
 
-from simpl import config  # flake8: noqa
-from simpl import git  # flake8: noqa
-from simpl.exceptions import *
+from simpl import config  # noqa
+from simpl import git  # noqa
+from simpl.exceptions import *  # noqa
+from simpl.__about__ import *  # noqa
 
 
 IS_TRAVIS_CI_ENV = all(map(os.environ.get, ['TRAVIS', 'CI']))


### PR DESCRIPTION
Puts all package information into `simpl/__about__.py` for an improved layout and cleaner  `simpl/__init__.py` and `setup.py` 

This PR bumps the version to `0.2.2` and I'll cut a release after. 