### PR TITLE
--ini error conditions

### DIFF
--- a/simpl/exceptions.py
+++ b/simpl/exceptions.py
@@ -17,7 +17,7 @@
 Warnings can be imported and subsequently disabled by
 calling the disable() classmethod.
 
-TODO(sam): add SimpleConfigException and NoGroupForOption
+TODO(sam): NoGroupForOption
 """
 
 import warnings
@@ -107,3 +107,17 @@ class SimplCalledProcessError(SimplException):
         """Include custom data in string."""
         return ("Command '%s' returned non-zero exit status %d"
                 % (self.cmd, self.returncode))
+
+
+class SimplConfigException(SimplException):
+
+    """Errors raised by simpl/config."""
+
+
+class SimplConfigUnknownOption(SimplConfigException):
+
+    """An option defined in the specified source has no match.
+
+    For example, a specified ini file has an option with no corresponding
+    config.Option.
+    """

--- a/simpl/git.py
+++ b/simpl/git.py
@@ -28,6 +28,7 @@ import errno
 import logging
 import os
 import pipes
+import re
 import shutil
 import tempfile
 import warnings
@@ -201,7 +202,7 @@ def git_list_branches(repo_dir):
     if current_branch:
         lines.remove(current_branch)
         current_branch = current_branch.replace('* ', '', 1)
-        if current_branch.startswith('(detached from '):
+        if re.match('\(.*detached.+\)', current_branch):
             branch, rest = current_branch.split(')', 1)
             branch = "%s)" % branch
             sha, msg = rest.split(None, 1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,7 +46,6 @@ class TestParsers(unittest.TestCase):
 class TestConfig(unittest.TestCase):
 
     def get_tempfile(self, *args, **kwargs):
-
         fp = tempfile.NamedTemporaryFile(*args, **kwargs)
         self.addCleanup(fp.close)
         return fp
@@ -96,7 +95,6 @@ class TestConfig(unittest.TestCase):
             cfg.parse([])
 
     def test_argparser_groups(self):
-
         opts = [
             config.Option('--baz'),
             config.Option('--password', group='secret'),
@@ -139,7 +137,6 @@ class TestConfig(unittest.TestCase):
         self.assertIn('--who', option_strings)
 
     def test_group_help_usage_output(self):
-
         opts = [
             config.Option('--baz'),
             config.Option('--password', group='secret'),
@@ -255,7 +252,6 @@ class TestConfig(unittest.TestCase):
 
     @mock.patch.object(sys, 'stderr')
     def test_mutually_exclusive_fails_excess(self, mock_stderr):
-
         opts = [
             config.Option('--foo'),
             # if *any* arg in the same mutually_exclusive group says
@@ -301,7 +297,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(myconf.more, False)
 
     def test_default_metaconfig_options(self):
-
         myconf = config.Config()
         metaconf = myconf._get_metaconfig_class()
         self.assertEqual(metaconf, config.MetaConfig)
@@ -309,7 +304,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(metaconf.options[0].args, ('--ini',))
 
     def test_metaconfig_ini(self):
-
         metaconf = textwrap.dedent(
             """
             [default]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,8 +63,8 @@ class TestConfig(unittest.TestCase):
             config.Option('--none'),
         ])
         cfg.parse([])
-        self.assertEquals(cfg.one, 1)
-        self.assertEquals(cfg.a, 'a')
+        self.assertEqual(cfg.one, 1)
+        self.assertEqual(cfg.a, 'a')
         self.assertIsNone(cfg.none)
 
     def test_items(self):
@@ -73,8 +73,8 @@ class TestConfig(unittest.TestCase):
             config.Option('--none'),
         ])
         cfg.parse([])
-        self.assertEquals(cfg.one, cfg['one'])
-        self.assertEquals(cfg['one'], 1)
+        self.assertEqual(cfg.one, cfg['one'])
+        self.assertEqual(cfg['one'], 1)
         self.assertIsNone(cfg['none'])
 
     @mock.patch.dict('os.environ', {'TEST_TWO': '2'})
@@ -85,8 +85,8 @@ class TestConfig(unittest.TestCase):
             config.Option('--two', required=True, env='TEST_TWO'),
         ])
         cfg.parse([])
-        self.assertEquals(cfg.one, 1)
-        self.assertEquals(cfg.two, '2')
+        self.assertEqual(cfg.one, 1)
+        self.assertEqual(cfg.two, '2')
 
     def test_required_negative(self):
         cfg = config.Config(options=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -336,36 +336,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(myconf.ham, 'glam')
         self.assertEqual(myconf.spam, 'rico')
 
-    def test_default_metaconfig_ini(self):
-        """A default ini file is looked for by the metaconfig.
-
-        Looks for '{cwd}/{prog}.ini' % (os.getcwd(), myconf.prog)
-        """
-        strfile = self.get_tempfile(dir=os.getcwd(), suffix='.ini')
-        prog = os.path.split(strfile.name)[-1].rsplit('.ini', 1)[0]
-        metaconf = textwrap.dedent(
-            """
-            [%s]
-            ham = glam
-            grand = slam
-            spam = rico
-            """
-        ) % prog
-        opts = [
-            config.Option('--ham'),
-            config.Option('--grand'),
-            config.Option('--spam'),
-        ]
-        strfile.write(metaconf.encode('utf-8'))
-        strfile.flush()
-        argv = ['program', '--ini', strfile.name]
-        myconf = config.Config(options=opts, argv=argv)
-        myconf.prog = prog
-        myconf.parse()
-        self.assertEqual(myconf.grand, 'slam')
-        self.assertEqual(myconf.ham, 'glam')
-        self.assertEqual(myconf.spam, 'rico')
-
     def test_metaconfig_ini_nooption_raises(self):
         """Test that ini options with no matches raises an error."""
         metaconf = textwrap.dedent(


### PR DESCRIPTION
This change raises exceptions on these conditions:
    - an explicitly defined ini file does not exist
    - a config option found in a loaded ini file
      does not correspond to a `config.Option`


Add `SimplConfigException` and `SimplConfigUnknownOption`

`SimplConfigUnknownOption` will be thrown if an ini file is
explicitly specified, but there are options in it that have
no match, i.e. no corresponding `config.Option`


Previously, if these conditions occurred, nothing would happen. @Gifflen spent quite a long time trying to figure out why the options defined in his ini file were not getting picked up by simpl. 

