### PR TITLE
feat(rest): add REST API Helpers v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Common Python libraries for:
 - [Configuration](#config)
 - [Logging](#logging)
 - [WSGI Middleware](#middleware)
+- [REST API Tooling](#rest)
 
 ## <a name="config"></a>Config
 
@@ -26,6 +27,15 @@ Includes sample middleware for use with WSGI apps including bottle.
 
 Middleware included:
 - CORS: handles CORS requests
+
+
+## <a name="rest"></a>REST API Tooling
+
+Helper code for handling RESTful APIs using bottle.
+
+Code included:
+- body: a decorator that parses a call body and passes it to a route as an argument. The decorator can apply a schema (any callable including a voluptuous.Schema), return a default, and enforce that a body is required.
+
 
 
 ## release

--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -1,4 +1,7 @@
 # Requirements that are required by optional components
 
+# For simpl.rest
+bottle==0.12.8
+
 # For simpl.middleware.cors
 WebOb==1.4.1

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2011-2015 Rackspace US, Inc.
+# All Rights Reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""REST-ful API Utilites."""
+
+import bottle
+
+
+def body(schema=None, types=None, required=False, default=None):
+    """Decorator to parse and validate API body.
+
+    :keyword schema: callable that accepts raw data and returns the coerced (or
+        unchanged) data if it is valid. It should raise an error if the data is
+        not valid.
+    :keyword types: supported content types (default is ['application/json'])
+    :keyword required: if true and no body specified will raise an error.
+    :keyword default: default value to return if no body supplied
+
+    Note: only json types are supported.
+    """
+    if not types:
+        types = ['application/json']
+    if not all('json' in t for t in types):
+        raise NotImplementedError("Only 'json' body supported.")
+
+    def wrap(fxn):
+        """Return a decorated callable."""
+        def wrapped(*args):
+            """Callable to called when the decorated function is called."""
+            data = bottle.request.json
+            if required and not data:
+                bottle.abort(400, "Call body cannot be empty")
+            if data is None:
+                data = default
+            if schema:
+                try:
+                    data = schema(data)
+                except (KeyboardInterrupt, SystemExit):
+                    raise  # don't catch and ignore attempts to end the app
+                except Exception as exc:
+                    bottle.abort(400, str(exc))
+            return fxn(data, *args)
+        return wrapped
+    return wrap

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2011-2015 Rackspace US, Inc.
+# All Rights Reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Test :mod:`simpl.rest`."""
+
+import unittest
+
+import bottle
+import mock
+import six
+
+from simpl import rest
+
+
+class TestBodyDecorator(unittest.TestCase):
+
+    """Tests for :func:`simpl.rest.body`."""
+
+
+    def test_decoration(self):
+        """Test decorated function is called."""
+        mock_handler = mock.Mock(return_value='X')
+        decorated = rest.body()(mock_handler)
+        self.assertTrue(callable(decorated))
+        self.assertEqual(decorated(), 'X')
+        mock_handler.assert_called_once()
+
+    @mock.patch.object(rest.bottle, 'request')
+    def test_schema(self, mock_request):
+        """Test schema callable is called."""
+        data = "100"
+        mock_request.json = data
+        mock_handler = mock.Mock()
+        route = rest.body(schema=int)(mock_handler)
+        route()
+        mock_handler.assert_called_once_with(int(data))
+
+    @mock.patch.object(rest.bottle, 'request')
+    def test_schema_fail(self, mock_request):
+        """Test schema is enforced."""
+        mock_request.json = 'ALPHA'
+        mock_handler = mock.Mock()
+        route = rest.body(schema=int)(mock_handler)
+        with self.assertRaises(bottle.HTTPError):
+            route()
+
+    @mock.patch.object(rest.bottle, 'request')
+    def test_required(self, mock_request):
+        """Test required is enforced."""
+        mock_request.json = None
+        mock_handler = mock.Mock()
+        route = rest.body(required=True)(mock_handler)
+        with self.assertRaises(bottle.HTTPError) as context:
+            route()
+        self.assertEqual(context.exception.body, 'Call body cannot be empty')
+
+    @mock.patch.object(rest.bottle, 'request')
+    def test_default(self, mock_request):
+        """Test default is returned (and schema is applied to it)."""
+        mock_request.json = None
+        mock_handler = mock.Mock()
+        route = rest.body(default='100', schema=int)(mock_handler)
+        route()
+        mock_handler.assert_called_once_with(100)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds the first of the `rest.py` helpers that handle common bottle needs when implementing our APIs. Needs such as parsing the body and query params.
