### PR TITLE
fix(git import)

### DIFF
--- a/simpl/__about__.py
+++ b/simpl/__about__.py
@@ -28,7 +28,7 @@ __title__ = 'simpl'
 __summary__ = ('simpl is a collection of useful, '
                'reusable, common python libraries')
 __url__ = 'https://github.com/checkmate/simpl'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __author__ = 'Rackers'
 __email__ = 'samuel.stavinoha@rackspace.com'
 __keywords__ = ['common', 'resuable', 'suitable', 'fruitful']

--- a/simpl/__init__.py
+++ b/simpl/__init__.py
@@ -16,8 +16,6 @@
 
 import os
 
-from simpl import config  # noqa
-from simpl import git  # noqa
 from simpl.exceptions import *  # noqa
 from simpl.__about__ import *  # noqa
 


### PR DESCRIPTION
Remove `from simpl import git.py` from `simpl/__init__.py` so the git
module warnings don't occur even when it is not being used.