### PR TITLE
chore(style): add pylint checks

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,7 +1,8 @@
 [Messages Control]
-# W0511: TODOs in code comments are fine.
-# W0142: *args and **kwargs are fine.
-disable=W0511,W0142
+enable=C,E,F
+disable=W,R,I,fixme,too-many-arguments,wildcard-import,no-absolute-import,bad-builtin,import-error
+# NOTE(larsbutler): import-error is a spurious message from a bug, it seems.
+# See https://bitbucket.org/logilab/pylint/issues/324/namespaces-and-virutlaenv.
 
 [BASIC]
 # Don't require docstrings on tests or Python Special Methods

--- a/simpl/git.py
+++ b/simpl/git.py
@@ -600,6 +600,7 @@ class GitRepo(object):
         """Create an annotated tag."""
         return git_tag(self.repo_dir, tagname, message=message, force=force)
 
+    # pylint: disable=invalid-name
     def ls(self):
         """Return a list of *all* files & dirs in the repo.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,5 +6,6 @@ flake8_docstrings
 mock
 nose
 nose-ignore-docstring
+pylint
 requests
 webtest

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,7 @@ commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=si
 # - tests may not have docstrings
 commands =
     flake8 setup.py simpl
-    # Skip linting errors; just write out a file that can be used for analysis
-    /bin/bash -c "pylint -f parseable {posargs:simpl} > pylint.log || true"
+    pylint simpl
 
 [flake8]
 #flake8 default settings

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,10 @@ commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=si
 # We use flake8 with the docstrings (pep257) plugin
 # We check tests for style also, but we use different criteria:
 # - tests may not have docstrings
-commands = flake8 setup.py simpl
+commands =
+    flake8 setup.py simpl
+    # Skip linting errors; just write out a file that can be used for analysis
+    /bin/bash -c "pylint -f parseable {posargs:simpl} > pylint.log || true"
 
 [flake8]
 #flake8 default settings


### PR DESCRIPTION
We use pylint in most of our codebases, many devs
add it to their dev cycle, and we commonly include pylint comments in our code which can help declare
intent when we have code that could be flagged by
pylint.

Notes: this does not block builds or tests