### PR TITLE
fix(config): formatter_class not working

### DIFF
--- a/simpl/config.py
+++ b/simpl/config.py
@@ -475,7 +475,8 @@ class Config(collections.MutableMapping):
         options = []
         for option in self._options:
             kwargs = option.kwargs.copy()
-            kwargs['default'] = argparse.SUPPRESS
+            if kwargs.get('default') is None:
+                kwargs['default'] = argparse.SUPPRESS
             temp = Option(*option.args, **kwargs)
             options.append(temp)
         parser = self.build_parser(options, permissive=permissive)
@@ -747,13 +748,19 @@ class MetaConfig(Config):
         Option('--ini', metavar='PATH',
                help=('Source some or all of the options from this ini file.'),
                type=normalized_path,
-               group=option_group, group_description=option_description),
+               group=option_group, group_description=option_description,
+               default=argparse.SUPPRESS),
     ]
 
     def __init__(self, options=None, **kwargs):
         """TODO(zns): add docstring."""
         options = options or self.options
         super(MetaConfig, self).__init__(options=options, **kwargs)
+
+    @property
+    def ini(self):
+        """Make sure to always return an ini value."""
+        return self._values.get('ini')
 
     def provision(self, conf):
         """Provision this metaconfig's config with what we gathered.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,8 +17,10 @@
 """Tests for simpl.config."""
 from __future__ import print_function
 
+import argparse
 import errno
 import os
+import string
 import sys
 import tempfile
 import textwrap
@@ -376,6 +378,40 @@ class TestConfig(unittest.TestCase):
             myconf.parse()
         self.assertEqual(errno.ENOENT, err.exception.errno)
         self.assertIn(expected_message, str(err.exception))
+
+    @mock.patch('sys.stdout', new_callable=six.StringIO)
+    def test_default_help_formatter(self, mock_stdout):
+        """Default Belp Formatter Still Works."""
+        OPTS = [
+            config.Option(
+                '--host',
+                help='Server address.',
+                default='127.0.0.1',
+            )
+        ]
+
+        self.maxDiff = None
+        conf = config.Config(
+            options=OPTS,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog='test')
+        try:
+            conf.parse(argv=['test.py', '-h'])
+        except SystemExit:
+            pass
+        expected = """\
+usage: test [-h] [--ini PATH] [--host HOST]
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --host HOST  Server address. (default: 127.0.0.1)
+
+initialization (metaconfig) arguments:
+  evaluated first and can be used to source an entire config
+
+  --ini PATH   Source some or all of the options from this ini file.
+"""
+        self.assertEqual(mock_stdout.getvalue(), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Defaults were being always overwritten by suppress
which prevented them from being returned. Fixing
that exposed an issue were the metaconfig was
always returning a “Default: None” in its help
string, so that had to be suppressed.
A test was added to check this.

Fixes #26