### PR TITLE
Add coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 # command to install dependencies
 install:
   - "pip install tox"
+  - "pip install coveralls"
 # run before the main script
 before_script:
   - "git --version"
@@ -13,3 +14,4 @@ env:
   - TOXENV=style
 # The following line tells Travis CI to build in a container
 sudo: false
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # simpl
+[![Build Status](https://travis-ci.org/checkmate/simpl.svg?branch=master)](https://travis-ci.org/checkmate/simpl)
+[![Coverage Status](https://coveralls.io/repos/checkmate/simpl/badge.svg?branch=master)](https://coveralls.io/r/checkmate/simpl?branch=master)
 
 Common Python libraries for:
 


### PR DESCRIPTION
Since we are already outputting coverage data in tox I've added support for historically tracking coverage with coveralls.io. There are also badges for travis and coveralls on the README.md