### PR TITLE
[incubator.rest] Request schema validation deco 

### DIFF
--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -2,6 +2,7 @@
 
 # For simpl.rest
 bottle==0.12.8
+voluptuous==0.8.7
 
 # For simpl.server
 eventlet==0.17.4

--- a/simpl/incubator/rest.py
+++ b/simpl/incubator/rest.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2011-2015 Rackspace US, Inc.
+# All Rights Reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Incubator utilities for :mod:`simpl.rest`."""
+
+import bottle
+import six
+import voluptuous as volup
+
+
+class MultiValidationError(Exception):
+
+    """Basically a re-imagining of a `voluptuous.MultipleInvalid` error.
+
+    Reformats multiple errors messages for easy debugging of invalid
+    Checkmatefiles.
+    """
+
+    def __init__(self, errors):
+        """MultiValidationError constructor.
+
+        :param errors:
+            List of `voluptuous.Invalid` or `voluptuous.MultipleInvalid`
+            exception objects.
+        """
+        self.errors = errors
+        self.message = self._generate_message()
+
+    def __str__(self):
+        """Just return the pre-computed message.
+
+        See :meth:`_generate_message`.
+        """
+        return self.message
+
+    def __repr__(self):
+        """Simple representation of the exception, with the full message."""
+        indented_message = '\n'.join(
+            sorted('\t' + x for x in self.message.split('\n'))
+        )
+        return (
+            '%(cls_name)s(\n%(message)s\n)'
+            % dict(cls_name=self.__class__.__name__, message=indented_message)
+        )
+
+    def _generate_message(self):
+        """Reformat `path` attributes of each `error` and create a new message.
+
+        Join `path` attributes together in a more readable way, to enable easy
+        debugging of an invalid Checkmatefile.
+
+        :returns:
+            Reformatted error paths and messages, as a multi-line string.
+        """
+        reformatted_paths = (
+            ''.join(
+                "[%s]" % str(x)
+                # If it's not a string, don't put quotes around it. We do this,
+                # for example, when the value is an int, in the case of a list
+                # index.
+                if isinstance(x, six.integer_types)
+                # Otherwise, assume the path node is a string and put quotes
+                # around the key name, as if we were drilling down into a
+                # nested dict.
+                else "['%s']" % str(x)
+                for x in error.path
+            )
+            for error in self.errors
+        )
+
+        messages = (error.msg for error in self.errors)
+        # combine each path with its message:
+        zipped = zip(reformatted_paths, messages)
+        combined_messages = (
+            '%(path)s: %(messages)s' % dict(path=path, messages=message)
+            for path, message in zipped
+        )
+
+        return '\n'.join(sorted(combined_messages))
+
+
+def coerce_one(schema=str):
+    """Expect the input sequence to contain a single value.
+
+    :keyword schema:
+        Custom schema to apply to the input value. Defaults to just string,
+        since this is designed for query params.
+    """
+    def validate(val):
+        """Unpack a single item from the inputs sequence and run validation.
+
+        NOTE(larsbutler): This code is highly opinionated for bottle, since
+        bottle query params are wrapped in a list, even if there is just a
+        single value for a given parameter.
+        """
+        [value] = val
+        return volup.Coerce(schema)(value)
+    return validate
+
+
+def coerce_many(schema=str):
+    """Expect the input to be a sequence of items which conform to `schema`."""
+    def validate(val):
+        """Apply schema check/version to each item."""
+        return [volup.Coerce(schema)(x) for x in val]
+    return validate
+
+
+def schema(body_schema=None, body_required=False, query_schema=None,
+           content_types=None, default_body=None):
+    """Decorator to parse and validate API body and query string.
+
+    This decorator allows one to define the entire 'schema' for an API
+    endpoint.
+
+    :keyword body_schema:
+        Callable that accepts raw data and returns the coerced (or unchanged)
+        body content if it is valid. Otherwise, an error should be raised.
+
+    :keyword body_required:
+        `True` if some body content is required by the request. Defaults to
+        `False`.
+
+    :keyword query_schema:
+        Callable that accepts raw data and returns the coerced (or unchanged)
+        query string content if it is valid. Otherwise, an error should be
+        raised.
+
+    :keyword content_types:
+        List of allowed contents types for request body contents. Defaults to
+        `['application/json']`.
+
+    :keyword default_body:
+        Default body value to pass to the endpoint handler if `body_required`
+        is `True` but no body was given. This can be useful for specifying
+        complex request body defaults.
+    """
+    if not content_types:
+        content_types = ['application/json']
+    if not all('json' in t for t in content_types):
+        raise NotImplementedError("Only 'json' body supported.")
+
+    def deco(func):
+        """Return a decorated callable."""
+        def wrapped(*args, **kwargs):
+            """Validate/coerce request body and parameters."""
+            try:
+                # validate the request body per the schema (if applicable):
+                body = bottle.request.json
+                if body is None:
+                    body = default_body
+                if body_required and not body:
+                    bottle.abort(400, 'Call body cannot be empty')
+                if body_schema:
+                    try:
+                        body = body_schema(body)
+                    except volup.MultipleInvalid as exc:
+                        raise MultiValidationError(exc.errors)
+
+                # validate the query string per the schema (if application):
+                query = bottle.request.query.dict
+                if query_schema is not None:
+                    try:
+                        query = query_schema(query)
+                    except volup.MultipleInvalid as exc:
+                        raise MultiValidationError(exc.errors)
+                if not query:
+                    # If the query dict is empty, just set it to None.
+                    query = None
+
+                # Pass `body` and `query` as kwargs to the decorated function.
+                return func(
+                    *args,
+                    body=body,
+                    query=query,
+                    **kwargs
+                )
+            except Exception as exc:
+                bottle.abort(400, str(exc))
+        return wrapped
+    return deco

--- a/tests/incubator/test_rest.py
+++ b/tests/incubator/test_rest.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2011-2015 Rackspace US, Inc.
+# All Rights Reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Tests for :mod:`simpl.incubator.rest`."""
+
+import unittest
+
+import bottle
+from simpl.incubator import rest
+import voluptuous as volup
+import webtest
+
+
+class TestSchemaDecorator(unittest.TestCase):
+
+    def setUp(self):
+        self.root_app = bottle.Bottle()
+        self.app = webtest.TestApp(self.root_app)
+
+        def callback(body=None, query=None):
+            return dict(body=body, query=query)
+        self.callback = callback
+
+    def test_no_schema(self):
+        # Use the decorator without the @ syntax:
+        self.callback = rest.schema()(self.callback)
+
+        self.root_app.route('/foo', callback=self.callback)
+        result = self.app.get('/foo')
+        self.assertEqual(dict(body=None, query=None), result.json)
+
+    def test_no_schema_with_body(self):
+        self.callback = rest.schema()(self.callback)
+
+        self.root_app.route('/foo', method='POST', callback=self.callback)
+        result = self.app.post_json('/foo', params={'a': 1})
+        self.assertEqual(dict(body={'a': 1}, query=None), result.json)
+
+    def test_body_schema_no_body(self):
+        body_schema = volup.Schema({
+            'a': int,
+            'b': [str],
+        })
+        self.callback = rest.schema(body_schema=body_schema)(self.callback)
+
+        self.root_app.route('/foo', method='POST', callback=self.callback)
+        # Empty request body
+        result = self.app.post_json('/foo', expect_errors=True)
+
+        self.assertEqual(400, result.status_int)
+
+    def test_body_schema_with_body(self):
+        body_schema = volup.Schema({
+            'a': volup.Coerce(int),
+            'b': [volup.Coerce(str)],
+        })
+        self.callback = rest.schema(body_schema=body_schema)(self.callback)
+
+        self.root_app.route('/foo', method='POST', callback=self.callback)
+        result = self.app.post_json('/foo', dict(a='1', b=['foo', 'bar']),
+                                    expect_errors=True)
+
+        self.assertEqual(
+            # Note that `a` in the body is converted to an int.
+            dict(body=dict(a=1, b=['foo', 'bar']), query=None),
+            result.json
+        )
+
+    def test_no_schema_with_query(self):
+        self.callback = rest.schema()(self.callback)
+
+        self.root_app.route('/foo', callback=self.callback)
+        result = self.app.get('/foo?a=1&b=2&a=foo')
+
+        self.assertEqual(
+            dict(body=None, query=dict(b=['2'], a=['1', 'foo'])),
+            result.json
+        )
+
+    def test_no_schema_with_body_and_query(self):
+        self.callback = rest.schema()(self.callback)
+
+        self.root_app.route('/foo', method='POST', callback=self.callback)
+        result = self.app.post_json(
+            '/foo?a=1&b=2&a=foo',
+            dict(d='3', e=['4', 'bar'])
+        )
+        self.assertEqual(
+            {'body': {'d': '3', 'e': ['4', 'bar']},
+             'query': {'a': ['1', 'foo'], 'b': ['2']}},
+            result.json
+        )
+
+    def test_body_required_body_empty(self):
+        self.callback = rest.schema(body_required=True)(self.callback)
+
+        self.root_app.route('/foo', method='POST', callback=self.callback)
+        result = self.app.post_json('/foo', expect_errors=True)
+
+        self.assertEqual(400, result.status_int)
+
+    def test_query_schema(self):
+        self.callback = rest.schema(query_schema=volup.Schema({
+            'a': rest.coerce_one(str),
+            'b': rest.coerce_many(int),
+        }))(self.callback)
+
+        self.root_app.route('/foo', callback=self.callback)
+        result = self.app.get('/foo?a=foo&b=1&b=2&b=3')
+
+        self.assertEqual(
+            dict(body=None, query=dict(a='foo', b=[1, 2, 3])),
+            result.json
+        )
+
+    def test_query_schema_fail(self):
+        self.callback = rest.schema(query_schema=volup.Schema({
+            'a': rest.coerce_one(str),
+            'b': rest.coerce_many(int),
+        }))(self.callback)
+
+        self.root_app.route('/foo', callback=self.callback)
+        # There are two values for `a`. We only expect one.
+        result = self.app.get('/foo?a=foo&b=bar&b=2&b=3', expect_errors=True)
+
+        self.assertEqual(400, result.status_int)
+
+
+class TestMultiValidationError(unittest.TestCase):
+
+    """Tests for :class:`chessboard.parser.MultiValidationError`.
+
+    Mostly, we need to tests the formatting of error messages.
+    """
+
+    def test_error_formatting(self):
+        """Test the formatting of error paths."""
+        schema = volup.Schema({
+            volup.Required('foo'): volup.Schema({
+                volup.Required('id'): str,
+                volup.Required('name'): str,
+                volup.Optional('description'): str,
+            }),
+        })
+
+        input_data = {
+            'foo': {
+                'id': 124,
+                'name': 'test',
+            },
+            'extra': 0,
+        }
+        with self.assertRaises(volup.MultipleInvalid) as mi:
+            schema(input_data)
+
+        mve = rest.MultiValidationError(mi.exception.errors)
+        expected_str = """\
+['extra']: extra keys not allowed
+['foo']['id']: expected str"""
+
+        expected_repr = """\
+MultiValidationError(
+\t['extra']: extra keys not allowed
+\t['foo']['id']: expected str
+)"""
+
+        expected_message = (
+            "['extra']: extra keys not allowed\n"
+            "['foo']['id']: expected str"
+        )
+
+        self.assertEqual(expected_str, str(mve))
+        self.assertEqual(expected_repr, repr(mve))
+        self.assertEqual(expected_message, mve.message)
+
+


### PR DESCRIPTION
It's a work-in-progress.

How to use:

```python
import bottle

from simpl import rest

import voluptuous as volup


FOO_QUERY_SCHEMA = volup.Schema({
    'a': rest.coerce_many(int),
    'b': rest.coerce_one(str),
})


@bottle.route('/foo')
@rest.schema(query_schema=FOO_QUERY_SCHEMA)
def foo(body=None, query=None):
    return dict(body=body, query=query)


def start():
    """Start a Juno Server."""
    app = bottle.default_app()
    bottle.run(app=app, host='0.0.0.0', port=8080)

if __name__ == '__main__':
    start()
```

Since some endpoints might want to accept multiple values for a given query parameter, the `One` and `Many` functions allow that to be specified and handled nicely.

This is somewhat opinionated for `bottle`, since query params from bottle requests are group into dicts of lists, keyed by the parameter name.