### PR TITLE
fix(rest): `rest.body` decorator missing kwargs

### DIFF
--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -60,7 +60,7 @@ def body(schema=None, types=None, required=False, default=None):
 
     def wrap(fxn):
         """Return a decorated callable."""
-        def wrapped(*args):
+        def wrapped(*args, **kwargs):
             """Callable to called when the decorated function is called."""
             data = bottle.request.json
             if required and not data:
@@ -74,7 +74,7 @@ def body(schema=None, types=None, required=False, default=None):
                     raise  # don't catch and ignore attempts to end the app
                 except Exception as exc:
                     bottle.abort(400, str(exc))
-            return fxn(data, *args)
+            return fxn(data, *args, **kwargs)
         return wrapped
     return wrap
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -33,8 +33,8 @@ class TestBodyDecorator(unittest.TestCase):
         mock_handler = mock.Mock(return_value='X')
         decorated = rest.body()(mock_handler)
         self.assertTrue(callable(decorated))
-        self.assertEqual(decorated(), 'X')
-        mock_handler.assert_called_once_with(None)
+        self.assertEqual(decorated('arg', kwarg=2), 'X')
+        mock_handler.assert_called_once_with(None, 'arg', kwarg=2)
 
     @mock.patch.object(rest.bottle, 'request')
     def test_schema(self, mock_request):


### PR DESCRIPTION
The decorator was not tested with a callable that
has kwargs in it’s signature. It failed if a kwarg
is passed. This adds a test for that and fixes the
bug.