### PR TITLE
Add Text Search Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Common Python libraries for:
 - [WSGI Middleware](#middleware)
 - [REST API Tooling](#rest)
 - [Date/Time (chronos)](#chronos)
-- [MongoDB Backedn Wrapper](#mongo)
+- [MongoDB Backend Wrapper](#mongo)
 
 ## <a name="config"></a>Config
 

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -289,6 +289,12 @@ def process_params(request, standard_params=STANDARD_QUERY_PARAMS,
         sort = list(itertools.chain(*(
             comma_separated_strings(str(k)) for k in sort)))
         query_fields['sort'] = sort
+    if 'q' in request.query:
+        search = request.query.getall('q')
+        search = list(itertools.chain(*(
+            comma_separated_strings(k) for k in search
+            if k)))
+        query_fields['q'] = search
     return query_fields
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ mock
 mongobox
 nose
 nose-ignore-docstring
+prettyprint
 pylint
 pyyaml
 requests

--- a/tests/test_db_mongodb.py
+++ b/tests/test_db_mongodb.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # All Rights Reserved.
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -31,25 +32,6 @@ class TestDB(mongodb.SimplDB):
 
     def tune(self):
         pass  # bypass async tuning in tests
-
-
-def build_search_string(strings):
-    """Emulate `rest.process_params` parsing of `q` param."""
-    assert isinstance(strings, list)
-    if len(strings) == 1:
-        name = {'name': strings[0]}
-    else:
-        name = {
-            '$or': [
-                {'name': {'$regex': s, '$options': 'i'}} for s in strings
-            ]
-        }
-    return {
-        '$or': [
-            {'$text': {'$search': ' '.join(strings)}},
-            name
-        ]
-    }
 
 
 class TestMongoDB(unittest.TestCase):
@@ -164,22 +146,22 @@ class TestMongoDB(unittest.TestCase):
         self.db.prose.save("B", {"name": "Johnny Walker",
                                  "keywords": "whisky health"})
         # Single word
-        search = build_search_string(['john'])
+        search = mongodb.build_text_search(['john'])
         result = self.db.prose.list(**search)
         self.assertEqual(result[0][0]['name'], "John Adams")
 
         # Second word
-        search = build_search_string(['adams'])
+        search = mongodb.build_text_search(['adams'])
         result = self.db.prose.list(**search)
         self.assertEqual(result[0][0]['name'], "John Adams")
 
         # Multiple words in search
-        search = build_search_string(['wealth', 'health'])
+        search = mongodb.build_text_search(['wealth', 'health'])
         result = self.db.prose.list(**search)
         self.assertEqual(result[1], 2)
 
         # Keyword
-        search = build_search_string(['whisky'])
+        search = mongodb.build_text_search(['whisky'])
         result = self.db.prose.list(**search)
         self.assertEqual(result[0][0]['name'], "Johnny Walker")
 
@@ -416,7 +398,6 @@ class TestMongoDBCapabilities(unittest.TestCase):
             fields={'_lock': 0, '_id': 0}
         )
         self.assertIsNone(obj)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -262,10 +262,17 @@ class TestProcessParams(unittest.TestCase):
 
     def test_standard(self):
         request = bottle.BaseRequest(environ={
-            'QUERY_STRING': 'limit=100&offset=0&q=txt&facets=status'
+            'QUERY_STRING': 'limit=100&offset=0&facets=status'
         })
         results = rest.process_params(request)
         self.assertEqual(results, {})
+
+    def test_text(self):
+        request = bottle.BaseRequest(environ={
+            'QUERY_STRING': 'q=txt'
+        })
+        results = rest.process_params(request)
+        self.assertEqual(results, {'q': ['txt']})
 
     def test_invalid(self):
         request = bottle.BaseRequest(environ={


### PR DESCRIPTION
When a text index exists on a collection and we want to search it using a `q=` query param, these patches can do that.
