### PR TITLE
simpl server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 before_script:
   - "git --version"
 # command to run tests
-script: tox
+script: tox -v
 env:
   - TOXENV=py27
   - TOXENV=py34

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Common Python libraries for:
 - [Logging](#logging)
 - [Secrets](#secrets)
 - [Python Utilites](#python)
+- [Servers](#server)
 - [WSGI Middleware](#middleware)
 - [REST API Tooling](#rest)
 - [Date/Time (chronos)](#chronos)
@@ -37,6 +38,13 @@ Helpers for managing sensitive values.
 Code we wished was built in to python (or was simpler to use):
 - dictionary and list merging
 - dictionary get/set/in by path
+
+
+## <a name="server"></a>Running a web service
+
+- Perform standard webserver configuration (address, port, server adapter, etc.) using the [config](#config) module
+- Run the bottle-based webservice using this configuration
+
 
 ## <a name="middleware"></a>WSGI middleware
 

--- a/pylintrc
+++ b/pylintrc
@@ -7,3 +7,4 @@ disable=W,R,I,fixme,too-many-arguments,wildcard-import,no-absolute-import,bad-bu
 [BASIC]
 # Don't require docstrings on tests or Python Special Methods
 no-docstring-rgx=(__.*__|[tT]est.*|setUp|tearDown)
+const-rgx=([A-Z_][A-Za-z0-9_]{2,30}$)

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,16 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.4',
 ]
 
+ENTRY_POINTS = {
+    'console_scripts': ['simpl=simpl.cli:main'],
+}
+
+
 package_attributes = {
     'name': about['__title__'],
     'description': about['__summary__'],
     'keywords': ' '.join(about['__keywords__']),
+    'entry_points': ENTRY_POINTS,
     'version': about['__version__'],
     'tests_require': TESTS_REQUIRE,
     'test_suite': 'tests',

--- a/simpl/cli.py
+++ b/simpl/cli.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simpl's base module for its command line interface."""
+
+from simpl.utils import cli as cli_utils
+
+
+PARSER = cli_utils.HelpfulParser(
+    prog='simpl',
+    description='Build somthing awesome.',
+)
+SUBPARSER = PARSER.add_subparsers(
+    title='commands',
+    description='Available commands',
+)
+
+
+def default_parser():
+    return PARSER
+
+
+def default_subparser():
+    return SUBPARSER
+
+
+def main(argv=None):
+
+    # the following code shouldn't need to change when
+    # we add a new subcommand.
+    args = default_parser().parse_args(argv)
+
+
+if __name__ == '__main__':
+
+    main()

--- a/simpl/cli.py
+++ b/simpl/cli.py
@@ -14,6 +14,10 @@
 
 """Simpl's base module for its command line interface."""
 
+import functools
+import logging
+
+from simpl import server
 from simpl.utils import cli as cli_utils
 
 
@@ -37,9 +41,18 @@ def default_subparser():
 
 def main(argv=None):
 
+    #
+    # `simpl server`
+    #
+    logging.basicConfig(level=logging.INFO)
+    server_func = functools.partial(server.main, argv=argv)
+    server_parser = server.attach_parser(default_subparser())
+    server_parser.set_defaults(_func=server_func)
+
     # the following code shouldn't need to change when
     # we add a new subcommand.
     args = default_parser().parse_args(argv)
+    args._func()
 
 
 if __name__ == '__main__':

--- a/simpl/cli.py
+++ b/simpl/cli.py
@@ -32,15 +32,17 @@ SUBPARSER = PARSER.add_subparsers(
 
 
 def default_parser():
+    """Return global argumentparser."""
     return PARSER
 
 
 def default_subparser():
+    """Return global argumentparser's subparser."""
     return SUBPARSER
 
 
 def main(argv=None):
-
+    """Entry point for the `simpl` command."""
     #
     # `simpl server`
     #

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -354,6 +354,12 @@ class Config(collections.MutableMapping):
         :param parser_kwargs: kwargs used to init argparse parsers.
         :param argv: argument strings (defaults to sys.argv)
         """
+        # de-dupe (this helps when using log.py and server.py)
+        options = options or []
+        for option in options:
+            while options.count(option) != 1:
+                options.remove(option)
+
         self._parser_kwargs = parser_kwargs or {}
         self._ini_paths = ini_paths or []
         self._ini_paths = [normalized_path(x) for x in self._ini_paths]
@@ -879,6 +885,28 @@ def comma_separated_pairs(value):
 def parse_key_format(value):
     """Handle string formats of key files."""
     return value.strip("'").replace('\\n', '\n')
+
+
+OPTIONS = {
+    'debug': Option(
+        "-d", "--debug",
+        default=False,
+        action="store_true",
+        help="turn on additional debugging inspection and "
+             "output including full HTTP requests and responses. "
+             "Log output includes source file path and line "
+             "numbers. Runs server in debug mode which may return "
+             "tracebacks in response body. "
+    ),
+    'quiet': Option(
+        "-q", "--quiet",
+        default=False,
+        action="store_true",
+        help="turn down logging to WARN (default is INFO) "
+             "and run application in quiet mode"
+    )
+}
+
 
 SINGLETON = None
 

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -447,7 +447,7 @@ class Config(collections.MutableMapping):
             raise AttributeError("'config' object has no attribute '%s'"
                                  % attr)
 
-    def build_parser(self, options, permissive=False, **override_kwargs):
+    def build_parser(self, options=None, permissive=False, **override_kwargs):
         """Construct an argparser from supplied options.
 
         :keyword override_kwargs: keyword arguments to override when calling
@@ -461,10 +461,16 @@ class Config(collections.MutableMapping):
         kwargs.update(override_kwargs)
         if 'fromfile_prefix_chars' not in kwargs:
             kwargs['fromfile_prefix_chars'] = '@'
-        if options:
-            for option in options:
-                option.add_argument(parser, permissive=permissive)
         parser = self._parser_class(**kwargs)
+        if options is None:
+            options = []
+            for _opt in self._options:
+                _kw = _opt.kwargs.copy()
+                if _kw.get('default') is None:
+                    _kw['default'] = argparse.SUPPRESS
+                options.append(Option(*_opt.args, **_kw))
+        for option in options:
+            option.add_argument(parser, permissive=permissive)
         return parser
 
     def cli_values(self, argv):

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -347,7 +347,7 @@ class Config(collections.MutableMapping):
     """Parses configuration sources."""
 
     def __init__(self, options=None, ini_paths=None, argv=None,
-                 **parser_kwargs):
+                 argparser_class=argparse.ArgumentParser, **parser_kwargs):
         """Initialize with list of options.
 
         :param ini_paths: optional paths to ini files to look up values from
@@ -362,7 +362,8 @@ class Config(collections.MutableMapping):
                         for option in self._options}
         self._argv = argv
         self._metaconfigure(argv=self._argv)
-        self._parser = argparse.ArgumentParser(**parser_kwargs)
+        self._parser_class = argparser_class
+        self._parser = self._parser_class(**parser_kwargs)
         self._prog = None
         self.ini_config = None
         self.pass_thru_args = []
@@ -460,10 +461,10 @@ class Config(collections.MutableMapping):
         kwargs.update(override_kwargs)
         if 'fromfile_prefix_chars' not in kwargs:
             kwargs['fromfile_prefix_chars'] = '@'
-        parser = argparse.ArgumentParser(**kwargs)
         if options:
             for option in options:
                 option.add_argument(parser, permissive=permissive)
+        parser = self._parser_class(**kwargs)
         return parser
 
     def cli_values(self, argv):

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -176,7 +176,7 @@ try:
     import keyring
 except ImportError:
     keyring = None  # pylint: disable=C0103
-from six.moves import configparser
+from six.moves import configparser  # pylint: disable=wrong-import-order
 
 LOG = logging.getLogger(__name__)
 

--- a/simpl/git.py
+++ b/simpl/git.py
@@ -338,9 +338,12 @@ def git_fetch(repo_dir, remote=None, refspec=None, verbose=False, tags=True):
     return execute_git_command(command, repo_dir=repo_dir)
 
 
-def git_pull(repo_dir, remote="origin", ref=None):
+def git_pull(repo_dir, remote="origin", ref=None, update_head_ok=False):
     """Do a git pull of `ref` from `remote`."""
-    command = ['git', 'pull', '--update-head-ok', pipes.quote(remote)]
+    command = ['git', 'pull']
+    if update_head_ok:
+        command.append('--update-head-ok')
+    command.append(pipes.quote(remote))
     if ref:
         command.append(ref)
     return execute_git_command(command, repo_dir=repo_dir)

--- a/simpl/incubator/rest.py
+++ b/simpl/incubator/rest.py
@@ -17,8 +17,8 @@
 import traceback
 
 import bottle
-import six
-import voluptuous as volup
+import six  # pylint: disable=wrong-import-order
+import voluptuous as volup  # pylint: disable=wrong-import-order
 
 from simpl import rest as simpl_rest
 
@@ -121,7 +121,7 @@ def coerce_many(schema=str):
     return validate
 
 
-def schema(body_schema=None, body_required=False, query_schema=None,
+def schema(body_schema=None, body_required=False, query_schema=None,  # noqa
            content_types=None, default_body=None):
     """Decorator to parse and validate API body and query string.
 
@@ -184,7 +184,7 @@ def schema(body_schema=None, body_required=False, query_schema=None,
                         raise MultiValidationError(exc.errors)
 
                 # validate the query string per the schema (if application):
-                query = bottle.request.query.dict
+                query = bottle.request.query.dict  # pylint: disable=no-member
                 if query_schema is not None:
                     try:
                         query = query_schema(query)

--- a/simpl/log.py
+++ b/simpl/log.py
@@ -55,21 +55,12 @@ OPTIONS = [
     #
     config.Option("--logconfig",
                   help="Optional logging configuration file"),
-    config.Option("-d", "--debug",
-                  default=False,
-                  action="store_true",
-                  help="turn on additional debugging inspection and "
-                  "output including full HTTP requests and responses. "
-                  "Log output includes source file path and line "
-                  "numbers"),
+    config.OPTIONS['debug'],
+    config.OPTIONS['quiet'],
     config.Option("-v", "--verbose",
                   default=False,
                   action="store_true",
                   help="turn up logging to DEBUG (default is INFO)"),
-    config.Option("-q", "--quiet",
-                  default=False,
-                  action="store_true",
-                  help="turn down logging to WARN (default is INFO)"),
 ]
 
 getLogger = logging.getLogger  # pylint: disable=C0103
@@ -119,8 +110,8 @@ def _get_debug_formatter(conf):
 
     :param conf: configurtration namespace (ex. argparser)
 
-    --debug: log line numbers and file data also
-    --verbose: standard debug
+    --debug: log line numbers, file data
+    --verbose: standard log format at a DEBUG loglevel
     --quiet: turn down logging output (logging.WARNING)
     default is logging.INFO
     """

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -23,7 +23,7 @@ import traceback
 
 import bottle
 try:
-    import yaml
+    import yaml  # pylint: disable=wrong-import-order
 except ImportError:
     yaml = None
 

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -254,3 +254,52 @@ class XTornadoServer(bottle.ServerAdapter):  # pylint: disable=R0903
         tornado.ioloop.IOLoop.instance().start()
 
 bottle.server_names['xtornado'] = XTornadoServer
+
+
+def attach_parser(subparser):
+    """Given a subparser, build and return the server parser."""
+    return subparser.add_parser(
+        'server',
+        help='Run a bottle based server',
+        parents=[
+            CONFIG.build_parser(
+                add_help=False,
+                # might need conflict_handler
+            ),
+        ],
+    )
+
+
+def run(conf):
+    """Simpl server command line interface."""
+    # TODO(sam): Need a way to pass arbitrary kwargs
+    # to server handlers.
+
+    # bottle_kwargs = {key.replace('-', '_'): val
+    #                  for key, val in zip(extras[::2], extras[1::2])}
+
+    try:
+        if conf.reloader and not os.getenv('BOTTLE_CHILD'):
+            LOG.info("Running bottle server with reloader.")
+        return bottle.run(
+            app=conf.app,
+            server=conf.server,
+            host=conf.host,
+            port=conf.port,
+            interval=conf.interval,
+            reloader=conf.reloader,
+            quiet=conf.quiet,
+            debug=conf.debug,
+        )
+    except KeyboardInterrupt:
+        sys.exit("\nKilled simpl server.")
+
+
+def main(argv=None):
+    """Entry point for server, runs based on parsed CONFIG."""
+    CONFIG.parse(argv=argv)
+    return run(CONFIG)
+
+
+if __name__ == '__main__':
+    main()

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -59,7 +59,7 @@ OPTIONS = [
         group='Server Options',
     ),
     config.Option(
-        '--debug', '-d',
+        '--debug-server',
         help=_fill(
             'Run bottle server with debug=True which is useful for '
             'development or troubleshooting. Warning: This may expose raw '
@@ -70,7 +70,7 @@ OPTIONS = [
         group='Server Options',
     ),
     config.Option(
-        '--quiet', '-q',
+        '--quiet-server',
         help=_fill(
             'Suppress bottle\'s output to stdout and stderr, e.g. '
             '"Bottle v0.12.8 server starting up..." and others.'),
@@ -288,8 +288,8 @@ def run(conf):
             port=conf.port,
             interval=conf.interval,
             reloader=conf.reloader,
-            quiet=conf.quiet,
-            debug=conf.debug,
+            quiet=conf.quiet_server,
+            debug=conf.debug_server,
         )
     except KeyboardInterrupt:
         sys.exit("\nKilled simpl server.")

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -292,6 +292,11 @@ def run(conf):
         options = {}
     else:
         options = copy.copy(conf.adapter_options)
+
+    # waiting for https://github.com/bottlepy/bottle/pull/783
+    if conf.app and (os.getcwd() not in sys.path):
+        sys.path.append(os.getcwd())
+
     try:
         if conf.reloader and not os.getenv('BOTTLE_CHILD'):
             LOG.info("Running bottle server with reloader.")

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -39,13 +39,13 @@ OPTIONS = [
     ),
     config.Option(
         '--host',
-        help='Proxy server address to bind to.',
+        help='Server address to bind to.',
         default='127.0.0.1',
         group='Server Options',
     ),
     config.Option(
         '--port', '-p',
-        help='Proxy server port to bind to.',
+        help='Server port to bind to.',
         type=int,
         default=8080,
         group='Server Options',

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -324,17 +324,17 @@ def _version_callback():
 def build_app(conf):
     """Do some setup and return the wsgi app."""
     if isinstance(conf.adapter_options, list):
-        conf.adapter_options = {key: val for _dict in conf.adapter_options
-                                for key, val in _dict.items()}
+        conf['adapter_options'] = {key: val for _dict in conf.adapter_options
+                                   for key, val in _dict.items()}
     elif conf.adapter_options is None:
-        conf.adapter_options = {}
+        conf['adapter_options'] = {}
     else:
-        conf.adapter_options = copy.copy(conf.adapter_options)
+        conf['adapter_options'] = copy.copy(conf.adapter_options)
 
     # get wsgi app the same way bottle does if it receives a string.
-    conf.app = conf.app or bottle.default_app()
+    conf['app'] = conf.app or bottle.default_app()
     if isinstance(conf.app, six.string_types):
-        conf.app = bottle.load_app(conf.app)
+        conf['app'] = bottle.load_app(conf.app)
     conf.app.route(path='/_simpl', method='GET', callback=_version_callback)
 
     if os.getenv('BOTTLE_CHILD'):
@@ -355,7 +355,7 @@ def run(conf):
 
     Expects configuration options defined in server.OPTIONS
     """
-    conf.app = build_app(conf)
+    conf['app'] = build_app(conf)
     # waiting for https://github.com/bottlepy/bottle/pull/783
     if conf.app and (os.getcwd() not in sys.path):
         sys.path.append(os.getcwd())

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -14,13 +14,17 @@
 
 """Bottle Server Module."""
 
+from __future__ import print_function
+
 import copy
 import logging
+import operator
 import os
 import sys
 import textwrap
 
 import bottle
+import six
 
 from simpl import config
 from simpl.utils import cli as cli_utils
@@ -59,26 +63,8 @@ OPTIONS = [
         default='xtornado',
         group='Server Options',
     ),
-    config.Option(
-        '--debug-server',
-        help=_fill(
-            'Run bottle server with debug=True which is useful for '
-            'development or troubleshooting. Warning: This may expose raw '
-            'tracebacks and unmodified error messages in responses! Note: '
-            'this is not an option to configure DEBUG level logging.'),
-        default=False,
-        action='store_true',
-        group='Server Options',
-    ),
-    config.Option(
-        '--quiet-server',
-        help=_fill(
-            'Suppress bottle\'s output to stdout and stderr, e.g. '
-            '"Bottle v0.12.8 server starting up..." and others.'),
-        default=False,
-        action='store_true',
-        group='Server Options',
-    ),
+    config.OPTIONS['debug'],
+    config.OPTIONS['quiet'],
     config.Option(
         '--no-reloader',
         default=True,
@@ -307,8 +293,8 @@ def run(conf):
             port=conf.port,
             interval=conf.interval,
             reloader=conf.reloader,
-            quiet=conf.quiet_server,
-            debug=conf.debug_server,
+            quiet=conf.quiet,
+            debug=conf.debug,
             **options
         )
     except KeyboardInterrupt:

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -16,10 +16,95 @@
 
 import logging
 import os
+import sys
+import textwrap
 
 import bottle
 
+from simpl import config
+from simpl.utils import cli as cli_utils
+
 LOG = logging.getLogger(__name__)
+
+_fill = lambda text: textwrap.fill(text, 50)
+
+OPTIONS = [
+    config.Option(
+        '--app', '-a',
+        help=("WSGI application to load by name.\n"
+              "Ex: package.module gets the module\n"
+              "    package.module:name gets the variable 'name'\n"
+              "    package.module.func() calls func() and gets the result"),
+        group='Server Options',
+    ),
+    config.Option(
+        '--host',
+        help='Proxy server address to bind to.',
+        default='127.0.0.1',
+        group='Server Options',
+    ),
+    config.Option(
+        '--port', '-p',
+        help='Proxy server port to bind to.',
+        type=int,
+        default=8080,
+        group='Server Options',
+    ),
+    config.Option(
+        '--server', '-s',
+        help=('Server adapter to use. To see more, run:\n'
+              '`python -c "import bottle;print('
+              'bottle.server_names.keys())"`\n'),
+        default='xtornado',
+        group='Server Options',
+    ),
+    config.Option(
+        '--debug', '-d',
+        help=_fill(
+            'Run bottle server with debug=True which is useful for '
+            'development or troubleshooting. Warning: This may expose raw '
+            'tracebacks and unmodified error messages in responses! Note: '
+            'this is not an option to configure DEBUG level logging.'),
+        default=False,
+        action='store_true',
+        group='Server Options',
+    ),
+    config.Option(
+        '--quiet', '-q',
+        help=_fill(
+            'Suppress bottle\'s output to stdout and stderr, e.g. '
+            '"Bottle v0.12.8 server starting up..." and others.'),
+        default=False,
+        action='store_true',
+        group='Server Options',
+    ),
+    config.Option(
+        '--no-reloader',
+        default=True,
+        dest='reloader',
+        action='store_false',
+        help=_fill(
+            'Disable bottle auto-reloading server, which automatically '
+            'restarts the server when file changes are detected. Note: '
+            'some server handlers, such as eventlet, do not support '
+            'auto-reloading.'),
+        group='Server Options',
+    ),
+    config.Option(
+        '--interval', '-i',
+        help='Auto-reloader interval in seconds',
+        type=int,
+        default=1,
+        group='Server Options',
+    ),
+]
+
+CONFIG = config.Config(
+    prog='simpl_server',
+    options=OPTIONS,
+    argparser_class=cli_utils.HelpfulParser,
+    formatter_class=cli_utils.SimplHelpFormatter
+)
 
 
 class EventletLogFilter(object):  # pylint: disable=R0903

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -24,7 +24,7 @@ import sys
 import textwrap
 
 import bottle
-import six
+import six  # pylint: disable=wrong-import-order
 
 import simpl
 
@@ -299,7 +299,7 @@ def fmt_pairs(obj, indent=4, sort_key=None):
         return ''
     longest = max(lengths)
     obj = sorted(obj, key=sort_key)
-    formatter = '%s{: <%d} {}' % (' '*indent, longest)
+    formatter = '%s{: <%d} {}' % (' ' * indent, longest)
     string = '\n'.join([formatter.format(k, v) for k, v in obj])
     return string
 
@@ -320,6 +320,7 @@ def _version_callback():
         'version': simpl.__version__,
         'url': simpl.__url__,
     }
+
 
 def build_app(conf):
     """Do some setup and return the wsgi app."""

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -334,30 +334,27 @@ def run(conf):
     if isinstance(conf.app, six.string_types):
         conf.app = bottle.load_app(conf.app)
 
-    try:
-        if os.getenv('BOTTLE_CHILD'):
-            if conf.reloader:
-                LOG.info("Running bottle server with reloader.")
-            if conf.app and not conf.quiet:
-                try:
-                    routes = fmt_routes(conf.app)
-                    if routes:
-                        print('\n{}'.format(fmt_routes(conf.app)), end='\n\n')
-                except AttributeError:
-                    pass
-        return bottle.run(
-            app=conf.app,
-            server=conf.server,
-            host=conf.host,
-            port=conf.port,
-            interval=conf.interval,
-            reloader=conf.reloader,
-            quiet=conf.quiet,
-            debug=conf.debug,
-            **options
-        )
-    except KeyboardInterrupt:
-        sys.exit("\nKilled simpl server.")
+    if os.getenv('BOTTLE_CHILD'):
+        if conf.reloader:
+            LOG.info("Running bottle server with reloader.")
+        if conf.app and not conf.quiet:
+            try:
+                routes = fmt_routes(conf.app)
+                if routes:
+                    print('\n{}'.format(fmt_routes(conf.app)), end='\n\n')
+            except AttributeError:
+                pass
+    return bottle.run(
+        app=conf.app,
+        server=conf.server,
+        host=conf.host,
+        port=conf.port,
+        interval=conf.interval,
+        reloader=conf.reloader,
+        quiet=conf.quiet,
+        debug=conf.debug,
+        **options
+    )
 
 
 def main(argv=None):

--- a/simpl/utils/cli.py
+++ b/simpl/utils/cli.py
@@ -45,3 +45,21 @@ class HelpfulParser(argparse.ArgumentParser):
             self.print_help()
         sys.stderr.write('\nerror: %s\n' % message)
         sys.exit(2)
+
+
+def kwarg(string, separator='='):
+    """Return a dict from a delimited string."""
+    if separator not in string:
+        raise ValueError("Separator '%s' not in value '%s'"
+                         % (separator, string))
+    if string.strip().startswith(separator):
+        raise ValueError("Value '%s' starts with separator '%s'"
+                         % (string, separator))
+    if string.strip().endswith(separator):
+        raise ValueError("Value '%s' ends with separator '%s'"
+                         % (string, separator))
+    if string.count(separator) != 1:
+        raise ValueError("Value '%s' should only have one '%s' separator"
+                         % (string, separator))
+    key, value = string.split(separator)
+    return {key: value}

--- a/simpl/utils/cli.py
+++ b/simpl/utils/cli.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2011-2015 Rackspace US, Inc.
+#
+# All Rights Reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""CLI utilities."""
+
+import argparse
+import os
+import sys
+
+
+
+SimplHelpFormatter = type('SimplHelpFormatter',
+                          (argparse.ArgumentDefaultsHelpFormatter,
+                           argparse.RawTextHelpFormatter), {})
+
+
+class HelpfulParser(argparse.ArgumentParser):
+
+    """An argparser that won't leave you hanging."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('formatter_class', SimplHelpFormatter)
+        super(HelpfulParser, self).__init__(*args, **kwargs)
+
+    def error(self, message, print_help=False):
+        if 'too few arguments' in message.lower():
+            target = sys.argv.pop(0)
+            sys.argv.insert(
+                0, os.path.basename(target) or os.path.relpath(target))
+            message = ("%s. Try getting help with `%s --help`"
+                       % (message, " ".join(sys.argv)))
+        if print_help:
+            self.print_help()
+        sys.stderr.write('\nerror: %s\n' % message)
+        sys.exit(2)
+

--- a/simpl/utils/cli.py
+++ b/simpl/utils/cli.py
@@ -43,6 +43,8 @@ class HelpfulParser(argparse.ArgumentParser):
                        % (message, " ".join(sys.argv)))
         if print_help:
             self.print_help()
+        else:
+            self.print_usage()
         sys.stderr.write('\nerror: %s\n' % message)
         sys.exit(2)
 

--- a/simpl/utils/cli.py
+++ b/simpl/utils/cli.py
@@ -19,7 +19,6 @@ import os
 import sys
 
 
-
 SimplHelpFormatter = type('SimplHelpFormatter',
                           (argparse.ArgumentDefaultsHelpFormatter,
                            argparse.RawTextHelpFormatter), {})
@@ -30,10 +29,12 @@ class HelpfulParser(argparse.ArgumentParser):
     """An argparser that won't leave you hanging."""
 
     def __init__(self, *args, **kwargs):
+        """Set formatter_class if it is not explicitly specified."""
         kwargs.setdefault('formatter_class', SimplHelpFormatter)
         super(HelpfulParser, self).__init__(*args, **kwargs)
 
     def error(self, message, print_help=False):
+        """Provide a more helpful message if there are too few arguments."""
         if 'too few arguments' in message.lower():
             target = sys.argv.pop(0)
             sys.argv.insert(
@@ -44,4 +45,3 @@ class HelpfulParser(argparse.ArgumentParser):
             self.print_help()
         sys.stderr.write('\nerror: %s\n' % message)
         sys.exit(2)
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,92 @@
+"""Functional tests for command line use."""
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
+
+import subprocess
+import sys
+import unittest
+
+import mock
+
+from simpl import cli as simpl_cli
+from simpl import server
+from simpl.utils import cli as cli_utils
+
+
+class TestSimplCLI(unittest.TestCase):
+
+    def test_simpl_command_is_there(self):
+
+        cmd = ['simpl', '--help']
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except (subprocess.CalledProcessError, OSError) as err:
+            msg = 'Error while running `%s`' % subprocess.list2cmdline(cmd)
+            self.fail(msg='%s --> %r' % (msg, err))
+
+    def test_help_output(self):
+        cmd = ['simpl', '--help']
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except (subprocess.CalledProcessError, OSError) as err:
+            msg = 'Error while running `%s`' % subprocess.list2cmdline(cmd)
+            self.fail(msg='%s --> %r' % (msg, err))
+        self.assertIn('usage', str(output).lower())
+
+    def test_simpl_global_parser(self):
+        parser = simpl_cli.PARSER
+        self.assertEqual(parser.prog, 'simpl')
+
+    @mock.patch.object(server, 'run')
+    def test_simpl_server(self, mock_server_run):
+        simpl_cli.main(['server'])
+
+    @mock.patch.object(server.bottle, 'run')
+    def test_simpl_server_adapter_options(self, mock_bottle_run):
+        simpl_cli.main(['server', '-o', 'great_option=real', 'verbose=1'])
+        mock_bottle_run.assert_called_with(
+            verbose='1', app=None, interval=1, quiet=False,
+            server='xtornado', port=8080, host='127.0.0.1',
+            debug=False, reloader=True, great_option='real')
+
+    @mock.patch.object(server.bottle, 'run')
+    def test_simpl_server_defaults(self, mock_bottle_run):
+        simpl_cli.main(['server'])
+        mock_bottle_run.assert_called_with(
+            app=None, interval=1, quiet=False, server='xtornado', port=8080,
+            host='127.0.0.1', debug=False, reloader=True)
+
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    def test_simpl_server_fail(self, mock_stderr, mock_server_run):
+        with self.assertRaises(SystemExit):
+            simpl_cli.main(['server', '--not-an-option'])
+        mock_stderr.flush()
+        mock_stderr.seek(0)
+        self.assertIn('unrecognized arguments: --not-an-option',
+                      mock_stderr.read())
+
+
+class TestSimplCLIUtils(unittest.TestCase):
+
+    @unittest.skipIf(sys.version_info >= (3, 0, 0),
+                     "Skipping beyond python 3.")
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    def test_helpfulparser(self, mock_stderr):
+        parser = cli_utils.HelpfulParser()
+        parser.add_subparsers()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(args=[])
+        mock_stderr.flush()
+        mock_stderr.seek(0)
+        output = mock_stderr.read()
+        exp_regex = ('\nerror: too few arguments. Try getting '
+                     'help with `.* --help`\n')
+        self.assertRegexpMatches(output, exp_regex)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import unittest
 
+import bottle
 import mock
 
 from simpl import cli as simpl_cli
@@ -49,7 +50,7 @@ class TestSimplCLI(unittest.TestCase):
     def test_simpl_server_adapter_options(self, mock_bottle_run):
         simpl_cli.main(['server', '-o', 'great_option=real', 'verbose=1'])
         mock_bottle_run.assert_called_with(
-            verbose='1', app=None, interval=1, quiet=False,
+            verbose='1', app=bottle.default_app(), interval=1, quiet=False,
             server='xtornado', port=8080, host='127.0.0.1',
             debug=False, reloader=True, great_option='real')
 
@@ -57,7 +58,8 @@ class TestSimplCLI(unittest.TestCase):
     def test_simpl_server_defaults(self, mock_bottle_run):
         simpl_cli.main(['server'])
         mock_bottle_run.assert_called_with(
-            app=None, interval=1, quiet=False, server='xtornado', port=8080,
+            app=bottle.default_app(),
+            interval=1, quiet=False, server='xtornado', port=8080,
             host='127.0.0.1', debug=False, reloader=True)
 
     @mock.patch('sys.stderr', new_callable=StringIO)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,8 +41,8 @@ class TestSimplCLI(unittest.TestCase):
         parser = simpl_cli.PARSER
         self.assertEqual(parser.prog, 'simpl')
 
-    @mock.patch.object(server, 'run')
-    def test_simpl_server(self, mock_server_run):
+    @mock.patch.object(server.bottle, 'run')
+    def test_simpl_server(self, mock_bottle_run):
         simpl_cli.main(['server'])
 
     @mock.patch.object(server.bottle, 'run')
@@ -61,7 +61,7 @@ class TestSimplCLI(unittest.TestCase):
             host='127.0.0.1', debug=False, reloader=True)
 
     @mock.patch('sys.stderr', new_callable=StringIO)
-    def test_simpl_server_fail(self, mock_stderr, mock_server_run):
+    def test_simpl_server_fail(self, mock_stderr):
         with self.assertRaises(SystemExit):
             simpl_cli.main(['server', '--not-an-option'])
         mock_stderr.flush()
@@ -86,6 +86,28 @@ class TestSimplCLIUtils(unittest.TestCase):
         exp_regex = ('\nerror: too few arguments. Try getting '
                      'help with `.* --help`\n')
         self.assertRegexpMatches(output, exp_regex)
+
+    def test_kwargs_succeed(self):
+
+        expected = {
+            'hello': 'world',
+        }
+        data = cli_utils.kwarg('hello=world')
+        self.assertEqual(data, expected)
+
+    def test_kwargs_fail(self):
+
+        strings = [
+            # cannot start with a delimiter
+            '=world'
+            # cannot end with the delimiter
+            'more=',
+            # must have at least one pair
+            'true',
+        ]
+        for string in strings:
+            with self.assertRaises(ValueError):
+                data = cli_utils.kwarg(string)
 
 
 if __name__ == '__main__':

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,15 +14,18 @@
 
 """Test :mod:`simpl.server`."""
 
+import multiprocessing
 import os
 import signal
 import socket
+import time
 import unittest
 
 import bottle
 import mock
 import requests
 
+from simpl import cli as simpl_cli
 from simpl import server
 
 
@@ -43,6 +46,16 @@ class TestServer(unittest.TestCase):
         resp = run_server('xeventlet')
         self.assertTrue(resp.ok)
         self.assertEqual(resp.content, b'<b>Hello xeventlet</b>!')
+
+    def test_simpl_server(self):
+        argv = ['server', '--quiet-server', '--port', str(get_free_port())]
+        proc = multiprocessing.Process(
+            target=simpl_cli.main, kwargs={'argv': argv})
+        proc.start()
+        time.sleep(.5)
+        # Ensure the process is up after 1/2 a second.
+        self.assertTrue(proc.is_alive())
+        proc.terminate()
 
 
 class TestEventletLogger(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -48,7 +48,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(resp.content, b'<b>Hello xeventlet</b>!')
 
     def test_simpl_server(self):
-        argv = ['server', '--quiet-server', '--port', str(get_free_port())]
+        argv = ['server', '--quiet', '--port', str(get_free_port())]
         proc = multiprocessing.Process(
             target=simpl_cli.main, kwargs={'argv': argv})
         proc.start()

--- a/tests/test_simpl_server.py
+++ b/tests/test_simpl_server.py
@@ -12,8 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import eventlet
-eventlet.monkey_patch()
+
+def setUpModule():
+    import eventlet
+    eventlet.monkey_patch(os=True)
+
+def tearDownModule():
+    # unpatch
+    import imp
+    import os  # noqa
+    import sys
+
+    import eventlet
+
+    imp.acquire_lock()
+    try:
+        sys.modules['os'] = eventlet.patcher.original('os')
+    finally:
+        imp.release_lock()
+
 
 import logging
 import multiprocessing

--- a/tests/test_simpl_server.py
+++ b/tests/test_simpl_server.py
@@ -1,0 +1,206 @@
+# Copyright 2015 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import eventlet
+eventlet.monkey_patch()
+
+import logging
+import multiprocessing
+import os
+import pprint
+import random
+import socket
+import string
+import subprocess
+import sys
+import threading
+import unittest
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
+import requests
+
+import simpl
+
+LOG = logging.getLogger(__name__)
+
+
+def get_free_port(host):
+    sock = socket.socket()
+    sock.bind((host, 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    del sock
+    return port
+
+
+def _queued_output(out):
+    """Use a separate process to read server stdout into a queue.
+
+    Returns the queue object. Use get() or get_nowait() to read
+    from it.
+    """
+    def _enqueue_output(_out, _queue):
+        for line in _out:
+            _queue.put(line)
+    output_queue = multiprocessing.Queue()
+    # I tried a Thread, it was blocking the main thread because
+    # of GIL I guess. This made me very confused.
+    process = multiprocessing.Process(
+        target=_enqueue_output, args=(out, output_queue))
+    process.daemon = True
+    process.start()
+    return output_queue
+
+
+class TestServerFunctional(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.host = '127.0.0.1'
+        cls.port = get_free_port(cls.host)
+        cls.url = 'http://%s:%s' % (cls.host, cls.port)
+        cls.test_env = ''.join(random.sample(string.hexdigits, 22))
+        # Using simpl.__path__ instead of just `simpl server`
+        # to ensure we don't get a rogue binary.
+        # Use sys.executable to ensure we run the server using
+        # the exact same python interpreter as this test is using.
+        exe = os.path.join(simpl.__path__[0], 'server.py')
+        assert os.path.isfile(exe)
+        argv = [
+            sys.executable,
+            exe,
+            '--host', cls.host,
+            '--port', str(cls.port),
+            '--server', 'eventlet',
+            '--verbose',
+            '--debug',
+            '--environment', cls.test_env,
+            '--no-reloader',
+        ]
+
+        server_started = "Listening on {url}/".format(url=cls.url)
+
+        # ensure a hard-coded os.environ when testing!
+        # Without the unbuffered flag this doesn't
+        # work in > Python 3.
+        _env = {
+            'PYTHONDONTWRITEBYTECODE': '1',
+            'PYTHONUNBUFFERED': '1',
+        }
+        # bufsize=1 means line buffered.
+        # universal_newlines=True makes stdout text and not bytes
+        cls.server = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            bufsize=1,
+            env=_env,
+        )
+
+        cls._timeout = 5
+        startup_timeout = threading.Timer(cls._timeout, cls.server.kill)
+        startup_timeout.daemon = True
+        startup_timeout.start()
+
+        cls.non_blocking_read_queue = _queued_output(cls.server.stdout)
+        # cls.server.poll() will return -9 if Timer kill() sends SIGKILL
+        while cls.server.poll() is None:
+            try:
+                line = cls.non_blocking_read_queue.get_nowait()
+            except queue.Empty:
+                continue
+            else:
+                LOG.debug("Test simpl server STDOUT: %s", line)
+                if server_started in line:
+                    startup_timeout.cancel()
+                    LOG.info("simpl server started successfully!")
+                    break
+
+    def setUp(self):
+        """Ensure that the server started."""
+        code = self.server.poll()
+        # if code is None: server running.
+        # if code is 0, server exited for some reason.
+        if code:
+            if code == -9:
+                self.fail("Failed to start simpl server within "
+                          "the %s second timeout!" % self._timeout)
+            else:
+                self.fail("Failed to start test simpl server process! "
+                          "Exit code: %s" % code)
+        if code == 0:
+            self.fail("Server died for some reason with a 0 exit code.")
+
+        self.session = requests.session()
+        # Set up retries to not fail during server startup delay
+        retry = requests.packages.urllib3.util.Retry(
+            total=5, backoff_factor=0.2)
+        adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+        self.session.mount(self.url, adapter)
+
+    @classmethod
+    def tearDownClass(cls):
+        while not cls.non_blocking_read_queue.empty():
+            line = cls.non_blocking_read_queue.get_nowait()
+            LOG.debug("POST-MORTEM test simpl server STDOUT: %s", line)
+        try:
+            cls.server.kill()
+        except OSError:
+            pass
+
+    def _check_response(self, response):
+        """Check for 500s and debug-tracebacks."""
+        if response.status_code == 500:
+            req = response.request
+            try:
+                body = response.json()
+                if 'traceback' in body:
+                    msg = ('Traceback from test simpl server '
+                           'when calling {m} {p}\n{tb}')
+                    self.fail(
+                        msg.format(m=req.method,
+                                   p=req.path_url,
+                                   tb=body['traceback'])  # fail
+                    )
+                else:
+                    self.fail(pprint.pformat(body, indent=2))
+            except (TypeError, ValueError):
+                pass
+
+    def test_simpl_version(self):
+        vers = self.session.get('{}/_simpl'.format(self.url))
+        self._check_response(vers)
+        expected = {
+            'version': simpl.__version__,
+            'url': simpl.__url__,
+        }
+        self.assertEqual(expected, vers.json())
+
+    def test_not_found(self):
+        response = self.session.get('{}/i/dont/exist'.format(self.url))
+        self._check_response(response)
+        self.assertEqual(404, response.status_code)
+
+
+if __name__ == '__main__':
+    opts = {}
+    if any(v in ' '.join(sys.argv) for v in ['--verbose', '-v']):
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+        opts['verbosity'] = 2
+    unittest.main(**opts)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/all-requirements.txt
        -r{toxinidir}/mongo-requirements.txt
        -r{toxinidir}/test-requirements.txt
-commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=simpl \
+commands = nosetests {posargs} --verbose --with-doctest --with-coverage --cover-package=simpl \
     --with-ignore-docstrings
 
 [testenv:py27mongo28]


### PR DESCRIPTION
This change installs a `simpl` command into your environment during package installation using the `console_scripts` entry point. The first available subcommand is `server`. You can now use `simpl server` to quickly run your app.

The interface is similar to that of [bottle's "command line interface"](http://bottlepy.org/docs/dev/tutorial.html#command-line-interface).

##### The simpl/server boilerplate and interface can be used a few different ways:

#### 1. Point `simpl server` to your routes
Example:

```python
# test_app.py

import bottle

@bottle.get('/')
def hello():
    return 'Hello World!'
```

Run the command

```
simpl server -a test_app -p 8888
Bottle v0.12.8 server starting up (using XTornadoServer())...
Listening on http://127.0.0.1:8888/
Hit Ctrl-C to quit.
```

test it...

```
you@localhost $ http get localhost:8888
HTTP/1.1 200 OK
Content-Length: 12
Content-Type: text/html; charset=UTF-8
Server: TornadoServer/4.2

Hello World!
```

Of course, this might not be how you choose to continue as your app matures


#### 2. Attach simpl's `server` subcommand to your parser

Admittedly, this technique is a little strange, and the code must be in the exact order as written below. But it works.

```python
import argparse

from simpl import server


parser = argparse.ArgumentParser()
server_parser = server.attach_parser(parser.add_subparsers())
server_parser.set_defaults(func=server.run)
args = awesome_parser.parse_args()

conf = config.init(options=server.OPTIONS)
conf.parse()
args._func(conf)
```

#### 3. Just use the server.OPTIONS, and run bottle however you want.

```python
import bottle
from simpl import server

conf = server.CONFIG
conf.parse()

b = bottle.Bottle()
# add middleware, routes to Bottle instance
conf['app'] = b
server.run(conf)
```

--------

### --help

```
you@localhost$ simpl server --help
usage: simpl server [-h] [--ini PATH] [--app APP] [--host HOST] [--port PORT]
                    [--server SERVER] [--debug-server] [--quiet-server]
                    [--no-reloader] [--interval INTERVAL]
                    [--adapter-options [ADAPTER_OPTIONS [ADAPTER_OPTIONS ...]]]

optional arguments:
  -h, --help            show this help message and exit

initialization (metaconfig) arguments:
  evaluated first and can be used to source an entire config

  --ini PATH            Source some or all of the options from this ini file.

Server Options:
  --app APP, -a APP     WSGI application to load by name.
                        Ex: package.module gets the module
                            package.module:name gets the variable 'name'
                            package.module.func() calls func() and gets the result
  --host HOST           Server address to bind to. (default: 127.0.0.1)
  --port PORT, -p PORT  Server port to bind to. (default: 8080)
  --server SERVER, -s SERVER
                        Server adapter to use. To see more, run:
                        `python -c "import bottle;print(bottle.server_names.keys())"`
                         (default: xtornado)
  --debug-server        Run bottle server with debug=True which is useful
                        for development or troubleshooting. Warning: This
                        may expose raw tracebacks and unmodified error
                        messages in responses! Note: this is not an option
                        to configure DEBUG level logging. (default: False)
  --quiet-server        Suppress bottle's output to stdout and stderr,
                        e.g. "Bottle v0.12.8 server starting up..." and
                        others. (default: False)
  --no-reloader         Disable bottle auto-reloading server, which
                        automatically restarts the server when file
                        changes are detected. Note: some server adapters,
                        such as eventlet, do not support auto-reloading. (default: False)
  --interval INTERVAL, -i INTERVAL
                        Auto-reloader interval in seconds (default: 1)
  --adapter-options [ADAPTER_OPTIONS [ADAPTER_OPTIONS ...]], -o [ADAPTER_OPTIONS [ADAPTER_OPTIONS ...]]
                        Key-value pairs separated by '=' to be passed to
                        the underlying server adapter, e.g. XEventletServer,
                        and are mapped to the adapter's self.options
                        instance attribute. Example usage:
                          simpl server -s xeventlet -o keyfile=~/mykey ciphers=GOST94
```