### PR TITLE
Use dict() instead of .dict for bottle.request.query

### DIFF
--- a/simpl/incubator/rest.py
+++ b/simpl/incubator/rest.py
@@ -169,7 +169,7 @@ def schema(body_schema=None, body_required=False, query_schema=None,
                         raise MultiValidationError(exc.errors)
 
                 # validate the query string per the schema (if application):
-                query = bottle.request.query.dict
+                query = dict(bottle.request.query)
                 if query_schema is not None:
                     try:
                         query = query_schema(query)


### PR DESCRIPTION
Bottle's request.query.dict method appears to do some strange things to
query params:

Request: GET /v0/myawesomeroute?foo=12345678
bottle.request.query.dict: {'foo': ['12345678']}
dict(bottle.request.query): {'foo': '12345678'}

I'm not sure why this happens with bottle, but it has to be wrong and
makes schema validation almost impossible. Using dict() seems to fix
the problem and allows proper validation.