### PR TITLE
fix(rest): filters must come back in mongo format

### DIFF
--- a/simpl/db/mongodb.py
+++ b/simpl/db/mongodb.py
@@ -631,3 +631,18 @@ def database(connection_string, db_class=SimplDB):
         instance = db_class(connection_string)
         database.singletons[connection_string] = instance
     return database.singletons[connection_string]
+
+
+def params_to_mongo(query_params):
+    """Convert HTTP query params to mongodb query syntax.
+
+    Converts the parse query params into a mongodb spec.
+
+    :param dict query_params: return of func:`rest.process_params`
+    """
+    if not query_params:
+        return {}
+    for key, value in query_params.items():
+        if isinstance(value, list):
+            query_params[key] = {'$in': value}
+    return query_params

--- a/tests/test_db_mongodb.py
+++ b/tests/test_db_mongodb.py
@@ -399,5 +399,23 @@ class TestMongoDBCapabilities(unittest.TestCase):
         )
         self.assertIsNone(obj)
 
+
+class TestParamQueries(unittest.TestCase):
+
+    """Test Query Param Parsing."""
+
+    def test_blank(self):
+        self.assertEqual(mongodb.params_to_mongo(None), {})
+        self.assertEqual(mongodb.params_to_mongo({}), {})
+        self.assertEqual(mongodb.params_to_mongo([]), {})
+
+    def test_or(self):
+        statuses = ['good', 'bad']
+        params = {
+            'status': statuses
+        }
+        converted = mongodb.params_to_mongo(params)
+        self.assertEqual(converted['status'], {'$in': statuses})
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since we’re coding this specifically to work with
bottle and mongodb, multiple filters should be
formatted as a mongodb $in filter condition.