### PR TITLE
Config: Refactor of CLI Parsing, Validation, and Precedence Handling

### DIFF
--- a/simpl/README.md
+++ b/simpl/README.md
@@ -74,7 +74,7 @@ def main(argv):
     conf.parse()
     print conf
     # advanced usage
-    cli_args = conf.parse_cli(argv=argv)
+    cli_args = conf.cli_values(argv=argv)
     env = conf.parse_env()
     secrets = conf.parse_keyring(namespace="app")
     ini = conf.parse_ini(ini_file_paths)

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -290,7 +290,7 @@ class Option(object):
                 if mutually_exclusive:
                     if not required:
                         required = kwargs.pop('required', None)
-                    mutexg_title = ('%s mutually-exclusive-group' % groupname)
+                    mutexg_title = '%s mutually-exclusive-group' % groupname
                     exists = [grp for grp in group._mutually_exclusive_groups
                               if grp.title == mutexg_title]
                     if exists:
@@ -714,18 +714,11 @@ class Config(collections.MutableMapping):
         secrets = self.parse_keyring(keyring_namespace)
         ini = self.parse_ini()
 
-        drop_nones = lambda d: {key: value for key, value in d.items()
-                                if value is not None}
-        # NOTE(larsbutler): We want to filter out nones, so that options with a
-        # None value at a higher precedence do not override values with a
-        # non-None value at a lower precedence. For example, if the defaults
-        # define a value for the option `foo`, and `args` contains `foo=None`,
-        # the `args` should override the default.
         results = defaults
-        results.update(drop_nones(ini))
-        results.update(drop_nones(secrets))
-        results.update(drop_nones(env))
-        results.update(drop_nones(args))
+        results.update(ini)
+        results.update(secrets)
+        results.update(env)
+        results.update(args)
         return results
 
     def parse(self, argv=None, keyring_namespace=None, strict=False):
@@ -976,7 +969,6 @@ def main():  # pragma: no cover
     if len(sys.argv) == 1:
         sys.argv.append('--help')
     myconf.parse()
-    print(myconf)
 
 if __name__ == '__main__':  # pragma: no cover
     main()

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -98,7 +98,7 @@ Example test.py file:
         print conf
 
         # advanced usage
-        cli_args = conf.parse_cli(argv=argv)
+        cli_args = conf.cli_values(argv)
         env = conf.parse_env()
         secrets = conf.parse_keyring(namespace="app")
         ini = conf.parse_ini(ini_file_paths)
@@ -169,6 +169,7 @@ import errno
 import logging
 import os
 import sys
+import warnings
 
 import simpl.exceptions
 
@@ -555,6 +556,9 @@ class Config(collections.MutableMapping):
         :keyword permissive: when true, does not validate required or extra
             arguments.
         """
+        warnings.warn("Calling `parse_cli` directly is deprecated. It will be "
+                      "removed in v0.8.0. Call `cli_values` and/or "
+                      "`validate_config` instead.", DeprecationWarning)
         if argv is None:
             argv = self._argv or sys.argv
         options = []
@@ -582,7 +586,7 @@ class Config(collections.MutableMapping):
             self.pass_thru_args = pass_thru + extras
         else:
             # maybe reset pass_thru_args on subsequent calls
-            # parse() -> parse_cli() is called post-plugin-init
+            # parse() -> cli_values() is called post-plugin-init
             self.pass_thru_args = []
         return vars(parsed)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,6 +171,13 @@ class TestConfig(unittest.TestCase):
         ])
         cfg.parse(['prog', '--foo'], strict=False)
 
+    def test_pass_thru(self):
+        cfg = config.Config(options=[
+            config.Option('--one', default=1),
+        ])
+        cfg.parse(['prog', '--one=1', '--',  '--pt'], strict=True)
+        self.assertEqual(cfg.pass_thru_args, ['--pt'])
+
     @mock.patch.dict('os.environ', {'TEST_TWO': '2'})
     def test_required(self):
         self.assertEqual(os.environ['TEST_TWO'], '2')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,6 +145,12 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(SystemExit):
             cfg.parse(['prog', '--foo'], strict=True)
 
+    def test_not_strict(self):
+        cfg = config.Config(options=[
+            config.Option('--one', default=1),
+        ])
+        cfg.parse(['prog', '--foo'], strict=False)
+
     @mock.patch.dict('os.environ', {'TEST_TWO': '2'})
     def test_required(self):
         self.assertEqual(os.environ['TEST_TWO'], '2')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,8 +48,17 @@ class TestConverters(unittest.TestCase):
         result = config.comma_separated_pairs("A=1,B=2,C=3")
         self.assertEqual(result, expected)
 
+    def test_read_from(self):
+        # TODO(zns): need to add this test
+        pass
 
+    def test_normalized_path(self):
+        # TODO(zns): need to add this test
+        pass
 
+    def parse_key_format(self):
+        # TODO(zns): need to add this test
+        pass
 
 
 @mock.patch.object(config.warnings, 'warn', mock.Mock())  # less noise in tests
@@ -96,6 +105,15 @@ class TestParsers(unittest.TestCase):
         self.assertEqual(
             self.conf.parse_env(),
             {'required': 'ENV2'})
+
+    def test_ini_parser(self):
+        # TODO(zns): need to add this test
+        pass
+
+    def test_keyring_parser(self):
+        # TODO(zns): need to add this test
+        pass
+
 
 @mock.patch.object(config.warnings, 'warn', mock.Mock())  # less noise in tests
 class TestConfig(unittest.TestCase):
@@ -456,7 +474,7 @@ class TestConfig(unittest.TestCase):
 
     @mock.patch('sys.stdout', new_callable=six.StringIO)
     def test_default_help_formatter(self, mock_stdout):
-        """Default Belp Formatter Still Works."""
+        """Default Help Formatter Still Works."""
         OPTS = [
             config.Option(
                 '--host',
@@ -474,18 +492,18 @@ class TestConfig(unittest.TestCase):
             conf.parse(argv=['test.py', '-h'])
         except SystemExit:
             pass
-        expected = """\
-usage: test [-h] [--ini PATH] [--host HOST]
+        expected = textwrap.dedent("""\
+        usage: test [-h] [--ini PATH] [--host HOST]
 
-optional arguments:
-  -h, --help   show this help message and exit
-  --host HOST  Server address. (default: 127.0.0.1)
+        optional arguments:
+          -h, --help   show this help message and exit
+          --host HOST  Server address. (default: 127.0.0.1)
 
-initialization (metaconfig) arguments:
-  evaluated first and can be used to source an entire config
+        initialization (metaconfig) arguments:
+          evaluated first and can be used to source an entire config
 
-  --ini PATH   Source some or all of the options from this ini file.
-"""
+          --ini PATH   Source some or all of the options from this ini file.
+        """)
         self.assertEqual(mock_stdout.getvalue(), expected)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,7 @@ class TestConverters(unittest.TestCase):
 
 
 
+@mock.patch.object(config.warnings, 'warn', mock.Mock())  # less noise in tests
 class TestParsers(unittest.TestCase):
 
     """Test Config Source Parsers.
@@ -96,6 +97,7 @@ class TestParsers(unittest.TestCase):
             self.conf.parse_env(),
             {'required': 'ENV2'})
 
+@mock.patch.object(config.warnings, 'warn', mock.Mock())  # less noise in tests
 class TestConfig(unittest.TestCase):
 
     def get_tempfile(self, *args, **kwargs):
@@ -487,6 +489,7 @@ initialization (metaconfig) arguments:
         self.assertEqual(mock_stdout.getvalue(), expected)
 
 
+@mock.patch.object(config.warnings, 'warn', mock.Mock())  # less noise in tests
 class TestConfigPrecedence(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This refactor/enhancement to `simpl.config` should help address recurring issues and increasing complexity in that module caused, IMO, but trying to overload parsing and validation in `parse_cli`. It's been problematic - see #89, #79 among other bugs.