### PR TITLE
FormatExceptionMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Includes sample middleware for use with WSGI apps including bottle.
 Middleware included:
 - CORS: handles CORS requests
 - Context: handles setting a threadlocal context and adds a transaction ID.
+- Errors: handles catching and formatting errors
 
 
 ## <a name="rest"></a>REST API Tooling

--- a/simpl/exceptions.py
+++ b/simpl/exceptions.py
@@ -121,3 +121,28 @@ class SimplConfigUnknownOption(SimplConfigException):
     For example, a specified ini file has an option with no corresponding
     config.Option.
     """
+
+
+class SimplHTTPError(SimplException):
+
+    """A custom http error class inspired by bottle's HTTPError.
+
+    Bottle has special treatment of its own HTTPErrors. Instances of
+    this class will be ignored by bottle. The benefit is that the
+    error handling logic in rest.py can deal with either exception
+    using the same code.
+
+    See rest.format_error_response()
+    """
+
+    default_status = 500
+
+    def __init__(self, status=None, body=None, exception=None,
+                 traceback=None, **options):
+        body = body if body is not None else ''
+        super(SimplHTTPError, self).__init__(body)
+        self.exception = exception
+        self.traceback = traceback
+        self.body = body
+        self.status_code = int(status) or self.default_status
+        self.options = options

--- a/simpl/exceptions.py
+++ b/simpl/exceptions.py
@@ -132,7 +132,7 @@ class SimplHTTPError(SimplException):
     error handling logic in rest.py can deal with either exception
     using the same code.
 
-    See rest.format_error_response()
+    See rest.httperror_handler
     """
 
     default_status = 500

--- a/simpl/middleware/errors.py
+++ b/simpl/middleware/errors.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2011-2015 Rackspace US, Inc.
+# All Rights Reserved.
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Middleware for errors and exceptions.
+
+Example:
+
+    # Allow this middleware to catch, handle and format all errors.
+
+    import bottle
+    from simpl.middleware import errors
+
+    app = bottle.default_app()
+    app.catchall = False
+    # To catch errors that occur in other middleware...
+    app = FormatExceptionMiddleware(app)
+    # Tell bottle to use rest.format_error_response when
+    # handling its own bottle.HTTPErrors
+    app.default_error_handler = rest.format_error_response
+    bottle.run(app=app)
+
+
+    Example responses (the following use catchall=False)
+    -----------------------------------------------------
+
+    An unexpected error if the server is in debug mode:
+
+        # raise ValueError()
+        {
+            "code": 500,
+            "description": "Internal Server Error",
+            "exception": "ValueError()",
+            "message": "Internal Server Error",
+            "traceback": "Traceback (most recent call last): ... ",
+        }
+
+
+    An "expected" error if the server is in debug mode:
+
+        # raise SimplHTTPError(body='Hey!', status=405)
+        {
+            "code": 405,
+            "description": "Hey!",
+            "exception": "SimplHTTPError('Hey!',)",
+            "message": "Method Not Allowed",
+            "traceback": "Traceback (most recent call last): ... ",
+        }
+
+
+    Unexpected error without debug mode:
+
+        # raise ValueError()
+        {
+            "code": 500,
+            "description": "We're sorry, something went wrong.",
+            "message": "Internal Server Error"
+        }
+
+
+    An "expected" error without debug mode:
+
+        # raise SimplHTTPError(body='Hey!', status=405)
+        {
+            "code": 405,
+            "description": "Hey!",
+            "message": "Method Not Allowed"
+        }
+"""
+
+import logging
+import traceback as tb_mod
+
+import bottle
+
+from simpl import exceptions as simpl_exc
+from simpl import rest
+
+LOG = logging.getLogger(__name__)
+
+
+def _catchall_enabled(app):
+    """Check the bottle app for catchall."""
+    while hasattr(app, 'app'):
+        if isinstance(app, bottle.Bottle):
+            break
+        app = app.app
+    if hasattr(app, 'catchall'):
+        return app.catchall
+    else:
+        return bottle.default_app().catchall
+
+
+class FormatExceptionMiddleware(object):
+
+    """Format outgoing exceptions.
+
+    Uses and is compatible-with bottle exception formatting.
+
+    - Handle Bottle Exceptions (even when catchall=False).
+    - Handle SimplHTTPError
+    - Fail-safe to a generic error (unexpected_error)
+
+    The code in this middleware is meant to be generic.
+    Don't catch and translate fancy exceptions here, do
+    it in the application logic or a separate middleware and
+    raise a bottle.HTTPError or a SimplHTTPError.
+    """
+
+    def __init__(self, app, conf=None):
+        """Initialize class."""
+        if _catchall_enabled(app) is True:
+            LOG.warning("Bottle's catchall flag is enabled for your app. "
+                        "The suggested use for this middleware is with "
+                        "catchall disabled, otherwise bottle will overwrite "
+                        "the exception context, sys.exc_info() and raise a "
+                        "bottle.HTTPError instead, which renders the error "
+                        "handling middleware less useful and less flexible.")
+        self.app = app
+        self.config = conf
+        LOG.debug("Added middleware: %s", type(self).__name__)
+
+    def __call__(self, environ, start_response):
+        """Catch exceptions and format them based on config."""
+        try:
+            return self.app(environ, start_response)
+        except bottle.HTTPError as error:
+            LOG.error("Formatting a bottle exception.",
+                      exc_info=error)
+
+            rest.format_error_response(error)
+            start_response(error.status_line, error.headerlist)
+            return error
+        except simpl_exc.SimplHTTPError as error:
+            LOG.error("Formatting a SimplHTTPError exception.",
+                      exc_info=error)
+            error = bottle.HTTPError(
+                status=error.status_code, body=error.body,
+                exception=error.exception or error,
+                traceback=error.traceback or tb_mod.format_exc())
+            rest.format_error_response(error)
+            start_response(error.status_line, error.headerlist)
+            return error
+        except Exception as error:  # pylint: disable=W0703
+            LOG.error("Formatting an unexpected exception.",
+                      exc_info=error)
+            error = bottle.HTTPError(
+                status=500, body=rest.UNEXPECTED_ERROR,
+                exception=error,
+                traceback=tb_mod.format_exc())
+            rest.format_error_response(error)
+            start_response(error.status_line, error.headerlist)
+            return error
+        except:  # noqa
+            LOG.error("Formatting an unknown exception.",
+                      exc_info=True)
+            error = bottle.HTTPError(
+                status=500, body=rest.UNEXPECTED_ERROR,
+                exception=sys.exc_info()[1],
+                traceback=tb_mod.format_exc())
+            rest.format_error_response(error)
+            start_response(error.status_line, error.headerlist)
+            return error

--- a/simpl/middleware/errors.py
+++ b/simpl/middleware/errors.py
@@ -79,6 +79,7 @@ Example:
 """
 
 import logging
+import sys
 import traceback as tb_mod
 
 import bottle

--- a/simpl/middleware/errors.py
+++ b/simpl/middleware/errors.py
@@ -78,11 +78,11 @@ from __future__ import print_function
 
 import logging
 import sys
-import traceback as tb_mod
+import traceback
 
 import bottle
 
-from simpl import exceptions as simpl_exc
+from simpl import exceptions
 from simpl import rest
 
 LOG = logging.getLogger(__name__)
@@ -140,13 +140,13 @@ class FormatExceptionMiddleware(object):
             rest.format_error_response(error)
             start_response(error.status_line, error.headerlist)
             return error
-        except simpl_exc.SimplHTTPError as error:
+        except exceptions.SimplHTTPError as error:
             LOG.error("Formatting a SimplHTTPError exception.",
                       exc_info=error)
             error = bottle.HTTPError(
                 status=error.status_code, body=error.body,
                 exception=error.exception or error,
-                traceback=error.traceback or tb_mod.format_exc())
+                traceback=error.traceback or traceback.format_exc())
             rest.format_error_response(error)
             start_response(error.status_line, error.headerlist)
             return error
@@ -156,7 +156,7 @@ class FormatExceptionMiddleware(object):
             error = bottle.HTTPError(
                 status=500, body=rest.UNEXPECTED_ERROR,
                 exception=error,
-                traceback=tb_mod.format_exc())
+                traceback=traceback.format_exc())
             rest.format_error_response(error)
             start_response(error.status_line, error.headerlist)
             return error
@@ -166,7 +166,7 @@ class FormatExceptionMiddleware(object):
             error = bottle.HTTPError(
                 status=500, body=rest.UNEXPECTED_ERROR,
                 exception=sys.exc_info()[1],
-                traceback=tb_mod.format_exc())
+                traceback=traceback.format_exc())
             rest.format_error_response(error)
             start_response(error.status_line, error.headerlist)
             return error

--- a/simpl/middleware/errors.py
+++ b/simpl/middleware/errors.py
@@ -36,47 +36,45 @@ Example:
 
     An unexpected error if the server is in debug mode:
 
-        # raise ValueError()
+        # raise TypeError('Poor type choice.')
         {
             "code": 500,
-            "description": "Internal Server Error",
-            "exception": "ValueError()",
-            "message": "Internal Server Error",
+            "exception": "TypeError('Poor type choice.',)",
+            "message": "We're sorry, something went wrong.",
+            "reason": "Internal Server Error",
             "traceback": "Traceback (most recent call last): ... ",
         }
-
 
     An "expected" error if the server is in debug mode:
 
         # raise SimplHTTPError(body='Hey!', status=405)
         {
             "code": 405,
-            "description": "Hey!",
             "exception": "SimplHTTPError('Hey!',)",
-            "message": "Method Not Allowed",
-            "traceback": "Traceback (most recent call last): ... ",
+            "message": "Hey!",
+            "reason": "Method Not Allowed",
+            "traceback": "Traceback (most recent call last): ..."
         }
-
 
     Unexpected error without debug mode:
 
-        # raise ValueError()
+        # raise TypeError('Poor type choice.')
         {
             "code": 500,
-            "description": "We're sorry, something went wrong.",
-            "message": "Internal Server Error"
+            "message": "We're sorry, something went wrong.",
+            "reason": "Internal Server Error"
         }
-
 
     An "expected" error without debug mode:
 
         # raise SimplHTTPError(body='Hey!', status=405)
         {
             "code": 405,
-            "description": "Hey!",
-            "message": "Method Not Allowed"
+            "message": "Hey!",
+            "reason": "Method Not Allowed"
         }
 """
+from __future__ import print_function
 
 import logging
 import sys

--- a/simpl/middleware/errors.py
+++ b/simpl/middleware/errors.py
@@ -25,9 +25,9 @@ Example:
     app.catchall = False
     # To catch errors that occur in other middleware...
     app = FormatExceptionMiddleware(app)
-    # Tell bottle to use rest.format_error_response when
+    # Tell bottle to use rest.httperror_handler when
     # handling its own bottle.HTTPErrors
-    app.default_error_handler = rest.format_error_response
+    app.default_error_handler = rest.httperror_handler
     bottle.run(app=app)
 
 
@@ -137,7 +137,7 @@ class FormatExceptionMiddleware(object):
             LOG.error("Formatting a bottle exception.",
                       exc_info=error)
 
-            rest.format_error_response(error)
+            rest.httperror_handler(error)
             start_response(error.status_line, error.headerlist)
             return error
         except exceptions.SimplHTTPError as error:
@@ -147,7 +147,7 @@ class FormatExceptionMiddleware(object):
                 status=error.status_code, body=error.body,
                 exception=error.exception or error,
                 traceback=error.traceback or traceback.format_exc())
-            rest.format_error_response(error)
+            rest.httperror_handler(error)
             start_response(error.status_line, error.headerlist)
             return error
         except Exception as error:  # pylint: disable=W0703
@@ -157,7 +157,7 @@ class FormatExceptionMiddleware(object):
                 status=500, body=rest.UNEXPECTED_ERROR,
                 exception=error,
                 traceback=traceback.format_exc())
-            rest.format_error_response(error)
+            rest.httperror_handler(error)
             start_response(error.status_line, error.headerlist)
             return error
         except:  # noqa
@@ -167,6 +167,6 @@ class FormatExceptionMiddleware(object):
                 status=500, body=rest.UNEXPECTED_ERROR,
                 exception=sys.exc_info()[1],
                 traceback=traceback.format_exc())
-            rest.format_error_response(error)
+            rest.httperror_handler(error)
             start_response(error.status_line, error.headerlist)
             return error

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -382,8 +382,8 @@ def format_error_response(error):
     status_code = error.status_code or 500
     output = {
         'code': status_code,
-        'description': error.body or UNEXPECTED_ERROR,
-        'message': bottle.HTTP_CODES.get(status_code, u''),
+        'message': error.body or UNEXPECTED_ERROR,
+        'reason': bottle.HTTP_CODES.get(status_code, u''),
     }
     if bottle.DEBUG:
         LOG.warning("Debug-mode server is returning traceback and error "
@@ -408,8 +408,8 @@ def format_error_response(error):
                 output['traceback'] = None
 
     # overwrite previous body attr with json
-    if isinstance(output['description'], bytes):
-        output['description'] = output['description'].decode(
+    if isinstance(output['message'], bytes):
+        output['message'] = output['message'].decode(
             'utf-8', errors='replace')
 
     # Default type and writer to json.

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -19,13 +19,16 @@ import itertools
 import json
 import logging
 import sys
-import traceback as tb_mod
+import traceback
+import warnings
 
 import bottle
 try:
     import yaml
 except ImportError:
     yaml = None
+
+from simpl import exceptions
 
 
 LOG = logging.getLogger(__name__)
@@ -403,7 +406,7 @@ def format_error_response(error):
             if any(sys.exc_info()):
                 # Otherwise, format_exc() returns "None\n"
                 # which is pretty silly.
-                output['traceback'] = tb_mod.format_exc()
+                output['traceback'] = traceback.format_exc()
             else:
                 output['traceback'] = None
 

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -298,7 +298,7 @@ def comma_separated_strings(value):
     return [str(k).strip() for k in value.split(",")]
 
 
-def format_error_response(error):
+def httperror_handler(error):
     """Format error responses properly, return the response body.
 
     This function can be attached to the Bottle instance as the

--- a/tests/test_middleware_errors.py
+++ b/tests/test_middleware_errors.py
@@ -39,7 +39,7 @@ class TestFmtExcMiddleware(unittest.TestCase):
         app.route(path='/simpl_500', method='GET', callback=simpl_500)
 
         def simpl_500_alt():
-            raise rest.HTTPError("And I feel bad.", status=500)
+            raise rest.HTTPError(body="And I feel bad.", status=500)
         app.route(path='/simpl_500_alt', method='GET', callback=simpl_500_alt)
 
         def bottle_500():
@@ -205,7 +205,7 @@ class TestFmtExcMiddleware(unittest.TestCase):
         self.assertIn('message', resp.json_body)
         self.assertEqual(
             resp.json_body['message'],
-            "We're sorry, something went wrong."
+            "And I feel bad."
         )
         self.assertEqual(
             resp.json_body['reason'],

--- a/tests/test_middleware_errors.py
+++ b/tests/test_middleware_errors.py
@@ -22,7 +22,7 @@ class TestFmtExcMiddleware(unittest.TestCase):
 
         app = bottle.default_app()
         app.catchall = False
-        app.default_error_handler = rest.format_error_response
+        app.default_error_handler = rest.httperror_handler
 
         def unexpected_error():
             raise Exception("My logic is bad.")
@@ -275,7 +275,7 @@ class TestFmtExcMiddlewareAlt(unittest.TestCase):
 
         app = bottle.default_app()
         app.catchall = False
-        app.default_error_handler = rest.format_error_response
+        app.default_error_handler = rest.httperror_handler
 
         app.route(path='/', method='GET',
                   callback=lambda: 'Hello')

--- a/tests/test_middleware_errors.py
+++ b/tests/test_middleware_errors.py
@@ -1,0 +1,269 @@
+"""Test FormatExceptionMiddleware."""
+
+import unittest
+
+import bottle
+import webtest
+import yaml
+
+from simpl import exceptions as simpl_exc
+from simpl.middleware import errors as errors_middleware
+from simpl import rest
+
+
+class TestFmtExcMiddleware(unittest.TestCase):
+
+    """Test logs and responses when Exception Middleware is enabled."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Init the tests by starting the bottle app and routes."""
+        super(TestFmtExcMiddleware, cls).setUpClass()
+
+        app = bottle.default_app()
+        app.catchall = False
+        app.default_error_handler = rest.format_error_response
+
+        def unexpected_error():
+            raise Exception("My logic is bad.")
+        app.route(path='/unexpected_error', method='GET',
+                  callback=unexpected_error)
+
+        def simpl_500():
+            raise simpl_exc.SimplHTTPError(body="Help.", status=500)
+        app.route(path='/simpl_500', method='GET', callback=simpl_500)
+
+        def simpl_500_alt():
+            raise rest.HTTPError("And I feel bad.", status=500)
+        app.route(path='/simpl_500_alt', method='GET', callback=simpl_500_alt)
+
+        def bottle_500():
+            raise bottle.HTTPError(body="Not sorry.", status=500)
+        app.route(path='/bottle_500', method='GET', callback=bottle_500)
+
+        def simpl_403():
+            raise simpl_exc.SimplHTTPError(body="Rejected.", status=403)
+        app.route(path='/simpl_403', method='GET',
+                  callback=simpl_403)
+
+        app = errors_middleware.FormatExceptionMiddleware(app)
+        cls.app = webtest.TestApp(app)
+
+    def test_unexpected_error_debug(self):
+        bottle.debug(True)
+        resp = self.app.get('/unexpected_error', expect_errors=True)
+        bottle.debug(False)
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertIn('exception', resp.json_body)
+        self.assertIn('traceback', resp.json_body)
+        self.assertEqual(
+            len(resp.json_body['traceback'].splitlines()),
+            14
+        )
+        self.assertEqual(
+            resp.json_body['exception'],
+            "Exception('My logic is bad.',)"
+        )
+        self.assertEqual(
+            resp.json_body['description'],
+            "We're sorry, something went wrong."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            500
+        )
+
+    def test_unexpected_error(self):
+        resp = self.app.get('/unexpected_error', expect_errors=True)
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertEqual(
+            resp.json_body['description'],
+            "We're sorry, something went wrong."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            500
+        )
+
+    def test_unexpected_error_yaml(self):
+        resp = self.app.get(
+            '/unexpected_error',
+            expect_errors=True,
+            headers={'Accept': 'application/x-yaml'}
+        )
+        self.assertEqual(resp.status_code, 500)
+        yaml_body = yaml.safe_load(resp.body)
+        self.assertIn('message', yaml_body)
+        self.assertIn('code', yaml_body)
+        self.assertIn('description', yaml_body)
+        self.assertEqual(
+            yaml_body['description'],
+            "We're sorry, something went wrong."
+        )
+        self.assertEqual(
+            yaml_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            yaml_body['code'],
+            500
+        )
+
+    def test_simpl_500(self):
+        resp = self.app.get('/simpl_500', expect_errors=True)
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertEqual(
+            resp.json_body['description'],
+            "Help."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            500
+        )
+
+    def test_simpl_500_alt(self):
+        resp = self.app.get('/simpl_500_alt', expect_errors=True)
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertEqual(
+            resp.json_body['description'],
+            "We're sorry, something went wrong."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            500
+        )
+
+    def test_bottle_500(self):
+        resp = self.app.get('/bottle_500', expect_errors=True)
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertEqual(
+            resp.json_body['description'],
+            "Not sorry."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            500
+        )
+
+    def test_simpl_403(self):
+        resp = self.app.get('/simpl_403', expect_errors=True)
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertEqual(
+            resp.json_body['description'],
+            "Rejected."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Forbidden"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            403
+        )
+
+
+class WorstMiddlewareEver(object):
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        raise Exception("Bugs!")
+
+
+class TestFmtExcMiddlewareAlt(unittest.TestCase):
+
+    """Tests FormatExceptionMiddleware works when other middleware fails."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Init the tests by starting the bottle app and routes."""
+        super(TestFmtExcMiddlewareAlt, cls).setUpClass()
+
+        app = bottle.default_app()
+        app.catchall = False
+        app.default_error_handler = rest.format_error_response
+
+        app.route(path='/', method='GET',
+                  callback=lambda: 'Hello')
+
+        app = WorstMiddlewareEver(app)
+        app = errors_middleware.FormatExceptionMiddleware(app)
+        cls.app = webtest.TestApp(app)
+
+    def setUp(self):
+        # Something weird is going on with bottle's threadlocals.
+        bottle.request.environ.clear()
+
+    def test_worst_middleware(self):
+        bottle.debug(True)
+        resp = self.app.get('/', expect_errors=True)
+        bottle.debug(False)
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn('message', resp.json_body)
+        self.assertIn('code', resp.json_body)
+        self.assertIn('description', resp.json_body)
+        self.assertIn('exception', resp.json_body)
+        self.assertIn('traceback', resp.json_body)
+        self.assertEqual(
+            len(resp.json_body['traceback'].splitlines()),
+            6
+        )
+        self.assertEqual(
+            resp.json_body['exception'],
+            "Exception('Bugs!',)"
+        )
+        self.assertEqual(
+            resp.json_body['description'],
+            "We're sorry, something went wrong."
+        )
+        self.assertEqual(
+            resp.json_body['message'],
+            "Internal Server Error"
+        )
+        self.assertEqual(
+            resp.json_body['code'],
+            500
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_middleware_errors.py
+++ b/tests/test_middleware_errors.py
@@ -59,9 +59,9 @@ class TestFmtExcMiddleware(unittest.TestCase):
         resp = self.app.get('/unexpected_error', expect_errors=True)
         bottle.debug(False)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertIn('exception', resp.json_body)
         self.assertIn('traceback', resp.json_body)
         self.assertEqual(
@@ -73,11 +73,11 @@ class TestFmtExcMiddleware(unittest.TestCase):
             "Exception('My logic is bad.',)"
         )
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -88,15 +88,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
     def test_unexpected_error(self):
         resp = self.app.get('/unexpected_error', expect_errors=True)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -107,15 +107,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
     def test_keyboard(self):
         resp = self.app.get('/keyboard', expect_errors=True)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -128,9 +128,9 @@ class TestFmtExcMiddleware(unittest.TestCase):
         resp = self.app.get('/keyboard', expect_errors=True)
         bottle.debug(False)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertIn('exception', resp.json_body)
         self.assertIn('traceback', resp.json_body)
         self.assertEqual(
@@ -142,11 +142,11 @@ class TestFmtExcMiddleware(unittest.TestCase):
             "KeyboardInterrupt('A funny signal.',)"
         )
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -162,15 +162,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 500)
         yaml_body = yaml.safe_load(resp.body)
-        self.assertIn('message', yaml_body)
+        self.assertIn('reason', yaml_body)
         self.assertIn('code', yaml_body)
-        self.assertIn('description', yaml_body)
+        self.assertIn('message', yaml_body)
         self.assertEqual(
-            yaml_body['description'],
+            yaml_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            yaml_body['message'],
+            yaml_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -181,15 +181,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
     def test_simpl_500(self):
         resp = self.app.get('/simpl_500', expect_errors=True)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "Help."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -200,15 +200,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
     def test_simpl_500_alt(self):
         resp = self.app.get('/simpl_500_alt', expect_errors=True)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -219,15 +219,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
     def test_bottle_500(self):
         resp = self.app.get('/bottle_500', expect_errors=True)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "Not sorry."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(
@@ -238,15 +238,15 @@ class TestFmtExcMiddleware(unittest.TestCase):
     def test_simpl_403(self):
         resp = self.app.get('/simpl_403', expect_errors=True)
         self.assertEqual(resp.status_code, 403)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "Rejected."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Forbidden"
         )
         self.assertEqual(
@@ -293,9 +293,9 @@ class TestFmtExcMiddlewareAlt(unittest.TestCase):
         resp = self.app.get('/', expect_errors=True)
         bottle.debug(False)
         self.assertEqual(resp.status_code, 500)
-        self.assertIn('message', resp.json_body)
+        self.assertIn('reason', resp.json_body)
         self.assertIn('code', resp.json_body)
-        self.assertIn('description', resp.json_body)
+        self.assertIn('message', resp.json_body)
         self.assertIn('exception', resp.json_body)
         self.assertIn('traceback', resp.json_body)
         self.assertEqual(
@@ -307,11 +307,11 @@ class TestFmtExcMiddlewareAlt(unittest.TestCase):
             "Exception('Bugs!',)"
         )
         self.assertEqual(
-            resp.json_body['description'],
+            resp.json_body['message'],
             "We're sorry, something went wrong."
         )
         self.assertEqual(
-            resp.json_body['message'],
+            resp.json_body['reason'],
             "Internal Server Error"
         )
         self.assertEqual(

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -321,7 +321,7 @@ class TestAPIBasics(unittest.TestCase):
         """Init the tests by starting the bottle app and routes."""
         super(TestAPIBasics, self).setUp()
         app = bottle.Bottle()
-        app.default_error_handler = rest.format_error_response
+        app.default_error_handler = rest.httperror_handler
         app.route(path='/', method='GET', callback=self.dummy_ok)
         app.route(path='/fail', method='GET', callback=self.dummy_fail)
         app.route(path='/bad', method='GET', callback=self.bad_code)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -19,6 +19,7 @@ import unittest
 import bottle
 import mock
 import six
+import yaml
 
 from simpl import rest
 import webtest
@@ -320,14 +321,13 @@ class TestAPIBasics(unittest.TestCase):
         """Init the tests by starting the bottle app and routes."""
         super(TestAPIBasics, self).setUp()
         app = bottle.Bottle()
-        app.default_error_handler = rest.error_formatter
+        app.default_error_handler = rest.format_error_response
+        app.route(path='/', method='GET', callback=self.dummy_ok)
+        app.route(path='/fail', method='GET', callback=self.dummy_fail)
+        app.route(path='/bad', method='GET', callback=self.bad_code)
+        app.route(path='/assert', method='GET', callback=self.dummy_assert)
+        app.route(path='/unhandled', method='GET', callback=self.dummy_unhandled)
         self.app = webtest.TestApp(app)
-
-        app.route('/', ['GET'], self.dummy_ok)
-        app.route('/fail', ['GET'], self.dummy_fail)
-        app.route('/bad', ['GET'], self.bad_code)
-        app.route('/assert', ['GET'], self.dummy_assert)
-        app.route('/unhandled', ['GET'], self.dummy_unhandled)
 
     @staticmethod
     def dummy_ok():
@@ -337,17 +337,18 @@ class TestAPIBasics(unittest.TestCase):
     @staticmethod
     def dummy_fail():
         """Dummy call for route testing."""
-        raise rest.HTTPError("Broken!", http_code=418, reason="Woops!")
+        raise bottle.HTTPError(body="Broken!", status=418)
 
     @staticmethod
     def bad_code():
         """Dummy call for route testing."""
-        raise rest.HTTPError("wat?!", http_code=419, reason="Because")
+        raise bottle.HTTPError(body="wat?!", status=419)
 
     @staticmethod
     def dummy_assert():
         """Dummy call for route testing."""
-        assert False, "Not what we expected"
+        raise bottle.HTTPError(body='Not what we expected',
+                               status=400)
 
     @staticmethod
     def dummy_unhandled():
@@ -359,11 +360,9 @@ class TestAPIBasics(unittest.TestCase):
         self.assertEqual(res.status, '404 Not Found')
         self.assertEqual(res.content_type, 'application/json')
         expected = {
-            'error': {
-                'code': 404,
-                'message': 'Not Found',
-                'description': "Not found: '/foo'",
-            }
+            'code': 404,
+            'reason': 'Not Found',
+            'message': "Not found: '/foo'",
         }
         self.assertEqual(res.json, expected)
 
@@ -372,11 +371,9 @@ class TestAPIBasics(unittest.TestCase):
         self.assertEqual(res.status, '405 Method Not Allowed')
         self.assertEqual(res.content_type, 'application/json')
         expected = {
-            'error': {
-                'code': 405,
-                'message': 'Method Not Allowed',
-                'description': "Method not allowed.",
-            }
+            'code': 405,
+            'reason': 'Method Not Allowed',
+            'message': "Method not allowed.",
         }
         self.assertEqual(res.json, expected)
 
@@ -385,12 +382,9 @@ class TestAPIBasics(unittest.TestCase):
         self.assertEqual(res.status, "418 I'm a teapot")
         self.assertEqual(res.content_type, 'application/json')
         expected = {
-            'error': {
-                'code': 418,
-                'message': "I'm a teapot",
-                'description': 'Broken!',
-                'reason': "Woops!",
-            }
+            'code': 418,
+            'reason': "I'm a teapot",
+            'message': 'Broken!',
         }
         self.assertEqual(res.json, expected)
 
@@ -399,12 +393,9 @@ class TestAPIBasics(unittest.TestCase):
         self.assertEqual(res.status, '419 Unknown')
         self.assertEqual(res.content_type, 'application/json')
         expected = {
-            'error': {
-                'code': 419,
-                'message': "Unknown",
-                'description': "wat?!",
-                'reason': 'Because',
-            }
+            'code': 419,
+            'reason': None,
+            'message': "wat?!",
         }
         self.assertEqual(res.json, expected)
 
@@ -413,11 +404,9 @@ class TestAPIBasics(unittest.TestCase):
         self.assertEqual(res.status, '400 Bad Request')
         self.assertEqual(res.content_type, 'application/json')
         expected = {
-            'error': {
-                'code': 400,
-                'message': 'Bad Request',
-                'description': "Not what we expected",
-            }
+            'code': 400,
+            'reason': 'Bad Request',
+            'message': "Not what we expected",
         }
         self.assertEqual(res.json, expected)
 
@@ -426,11 +415,9 @@ class TestAPIBasics(unittest.TestCase):
         self.assertEqual(res.status, '500 Internal Server Error')
         self.assertEqual(res.content_type, 'application/json')
         expected = {
-            'error': {
-                'code': 500,
-                'message': 'Internal Server Error',
-                'description': "Unexpected error",
-            }
+            'code': 500,
+            'reason': 'Internal Server Error',
+            'message': "Internal Server Error",
         }
         self.assertTrue(res.body.lower().find(b'internal') > 0)
         self.assertEqual(res.body.lower().find(b'sensitive'), -1)
@@ -441,13 +428,13 @@ class TestAPIBasics(unittest.TestCase):
                            headers={'Accept': 'application/x-yaml'},
                            expect_errors=True)
         self.assertEqual(res.content_type, 'application/x-yaml')
-        expected = b"""\
-error:
-  code: 404
-  description: 'Not found: ''/foo'''
-  message: Not Found
-"""
-        self.assertEqual(res.body, expected)
+        expected = {
+            'code': 404,
+            'reason': 'Not Found',
+            'message': "Not found: '/foo'",
+        }
+        actual = yaml.safe_load(res.body)
+        self.assertEqual(actual, expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Includes an updated error formatting function and custom httperror class.

We need to deprecate/remove and maybe add backwards compatibility for the following:

  - https://github.com/checkmate/simpl/blob/v0.7.1/simpl/rest.py#L306-L368
  - https://github.com/checkmate/simpl/blob/v0.7.1/simpl/rest.py#L33-L41

The current pull request is an update/upgrade/refactor of these.

The suggested use of bottle for consistent error handling and formatting becomes:

```python
app = bottle.default_app()
app.catchall = False
app.default_error_handler = rest.format_error_response
app = FormatExceptionMiddleware(app)
bottle.run(app=app)
```

This allows your app to handle unexpected exceptions in your routehandler logic OR in other middleware. Turning catchall off is beneficial in case any error handling logic needs access to the exception context, i.e. the return value of `sys.exc_info()`. If bottle always handles your errors, `sys.exc_info()` always returns `(None, None, None)`.

Fixes #83 