### PR TITLE
fix(exceptions): drop unnecessary except/raises

### DIFF
--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -68,8 +68,6 @@ def body(schema=None, types=None, required=False, default=None):
             if schema:
                 try:
                     data = schema(data)
-                except (KeyboardInterrupt, SystemExit):
-                    raise  # don't catch and ignore attempts to end the app
                 except Exception as exc:
                     bottle.abort(400, str(exc))
             return fxn(data, *args, **kwargs)

--- a/simpl/secrets.py
+++ b/simpl/secrets.py
@@ -29,8 +29,6 @@ def hide_url_password(url):
         parsed = parse.urlsplit(url)
         if parsed.password:
             return url.replace(':%s@' % parsed.password, ':*****@')
-    except (KeyboardInterrupt, SystemExit):
-        raise
     except Exception:  # pylint: disable=W0703
         pass
     return url


### PR DESCRIPTION
As noted by @mgeisler, KeyboardInterrupt and
SystemExit do not inherit from Exception (they
inherit from BaseException). So they will not be
caught by `except Exception`. Therefore they don’t
need to be caught explicitly and reraised.